### PR TITLE
feat: app/wallet clients

### DIFF
--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -75,12 +75,12 @@ export async function authenticate(request: FastifyRequest<{ Body: AuthenticateR
       signature,
     });
     if (update.isOk()) {
-      reply.send();
+      reply.send(update.value);
     } else {
       reply.code(500).send({ error: update.error.message });
     }
   } else {
-    if (channel.error.errCode === "not_found") reply.code(401).send();
+    if (channel.error.errCode === "not_found") reply.code(401).send({ error: "Unauthorized " });
     reply.code(500).send({ error: channel.error.message });
   }
 }
@@ -97,7 +97,7 @@ export async function status(request: FastifyRequest, reply: FastifyReply) {
     }
     reply.send(res);
   } else {
-    if (channel.error.errCode === "not_found") reply.code(401).send();
+    if (channel.error.errCode === "not_found") reply.code(401).send({ error: "Unauthorized" });
     reply.code(500).send({ error: channel.error.message });
   }
 }

--- a/apps/relay/src/server.ts
+++ b/apps/relay/src/server.ts
@@ -63,7 +63,7 @@ export class RelayServer {
             if (channelToken) {
               request.channelToken = channelToken;
             } else {
-              reply.code(401).send();
+              reply.code(401).send({ error: "Unauthorized " });
               return;
             }
           });

--- a/packages/connect/src/actions/authenticate.test.ts
+++ b/packages/connect/src/actions/authenticate.test.ts
@@ -1,0 +1,68 @@
+import { createWalletClient } from "../clients/createWalletClient";
+import { jest } from "@jest/globals";
+
+describe("authenticate", () => {
+  const client = createWalletClient({
+    relayURI: "https://connect.farcaster.xyz",
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const message = "example.com wants you to sign in with your Ethereum account = [...]";
+  const signature = "0xabcd1234";
+  const fid = 1;
+  const username = "alice";
+  const bio = "I'm a little teapot who didn't fill out my bio";
+  const displayName = "Alice Teapot";
+  const pfpUrl = "https://example.com/alice.png";
+
+  const statusResponseDataStub = {
+    state: "completed",
+    nonce: "abcd1234",
+    connectURI: "farcaster://connect?nonce=abcd1234[...]",
+    message,
+    signature,
+    fid,
+    username,
+    bio,
+    displayName,
+    pfpUrl,
+  };
+
+  test("constructs API request", async () => {
+    const response = new Response(JSON.stringify(statusResponseDataStub));
+    const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+    const res = await client.authenticate({
+      channelToken: "some-channel-token",
+      message,
+      signature,
+      fid,
+      username,
+      bio,
+      displayName,
+      pfpUrl,
+    });
+
+    expect(res.response).toEqual(response);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/connect/authenticate", {
+      method: "POST",
+      body: JSON.stringify({
+        message,
+        signature,
+        fid,
+        username,
+        bio,
+        displayName,
+        pfpUrl,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer some-channel-token",
+      },
+    });
+  });
+});

--- a/packages/connect/src/actions/authenticate.ts
+++ b/packages/connect/src/actions/authenticate.ts
@@ -1,0 +1,28 @@
+import { StatusResponse } from "./status";
+import { post, AsyncHttpResponse } from "../clients/transports/http";
+import { Client } from "../clients/createClient";
+
+export interface AuthenticateArgs extends AuthenticateRequest {
+  channelToken: string;
+}
+
+interface AuthenticateRequest {
+  message: string;
+  signature: `0x${string}`;
+  fid: number;
+  username: string;
+  bio: string;
+  displayName: string;
+  pfpUrl: string;
+}
+
+export type AuthenticateResponse = StatusResponse;
+
+const path = "connect/authenticate";
+
+export const authenticate = async (
+  client: Client,
+  { channelToken, ...request }: AuthenticateArgs,
+): AsyncHttpResponse<AuthenticateResponse> => {
+  return post<AuthenticateRequest, AuthenticateResponse>(client, path, request, { authToken: channelToken });
+};

--- a/packages/connect/src/actions/connect.test.ts
+++ b/packages/connect/src/actions/connect.test.ts
@@ -1,0 +1,46 @@
+import { createAppClient } from "../clients/createAppClient";
+import { jest } from "@jest/globals";
+
+describe("connect", () => {
+  const client = createAppClient({
+    relayURI: "https://connect.farcaster.xyz",
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const siweUri = "https://example.com/login";
+  const domain = "example.com";
+  const nonce = "abcd1234";
+
+  const connectResponseDataStub = {
+    channelToken: "some-channel-token",
+    state: "completed",
+  };
+
+  test("constructs API request", async () => {
+    const response = new Response(JSON.stringify(connectResponseDataStub));
+    const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+    const res = await client.connect({
+      siweUri,
+      domain,
+      nonce,
+    });
+
+    expect(res.response).toEqual(response);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/connect", {
+      method: "POST",
+      body: JSON.stringify({
+        siweUri,
+        domain,
+        nonce,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+});

--- a/packages/connect/src/actions/connect.ts
+++ b/packages/connect/src/actions/connect.ts
@@ -1,0 +1,24 @@
+import { Client } from "../clients/createClient";
+import { AsyncHttpResponse, post } from "../clients/transports/http";
+
+export type ConnectArgs = ConnectRequest;
+
+interface ConnectRequest {
+  siweUri: string;
+  domain: string;
+  nonce?: string;
+  notBefore?: string;
+  expirationTime?: string;
+  requestId?: string;
+}
+
+export interface ConnectResponse {
+  channelToken: string;
+  connectURI: string;
+}
+
+const path = "connect";
+
+export const connect = async (client: Client, { ...request }: ConnectArgs): AsyncHttpResponse<ConnectResponse> => {
+  return post<ConnectRequest, ConnectResponse>(client, path, request);
+};

--- a/packages/connect/src/actions/status.test.ts
+++ b/packages/connect/src/actions/status.test.ts
@@ -1,0 +1,36 @@
+import { createAppClient } from "../clients/createAppClient";
+import { jest } from "@jest/globals";
+
+describe("status", () => {
+  const client = createAppClient({
+    relayURI: "https://connect.farcaster.xyz",
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const statusResponseDataStub = {
+    state: "pending",
+    nonce: "abcd1234",
+    connectURI: "farcaster://connect?nonce=abcd1234[...]",
+  };
+
+  test("constructs API request", async () => {
+    const response = new Response(JSON.stringify(statusResponseDataStub));
+    const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+    const res = await client.status({
+      channelToken: "some-channel-token",
+    });
+
+    expect(res.response).toEqual(response);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/connect/status", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer some-channel-token",
+      },
+    });
+  });
+});

--- a/packages/connect/src/actions/status.ts
+++ b/packages/connect/src/actions/status.ts
@@ -1,0 +1,25 @@
+import { Client } from "../clients/createClient";
+import { get, AsyncHttpResponse } from "../clients/transports/http";
+
+export interface StatusArgs {
+  channelToken: string;
+}
+
+export interface StatusResponse {
+  state: "pending" | "completed";
+  nonce: string;
+  connectURI: string;
+  message?: string;
+  signature?: `0x${string}`;
+  fid?: number;
+  username?: string;
+  bio?: string;
+  displayName?: string;
+  pfpUrl?: string;
+}
+
+const path = "connect/status";
+
+export const status = async (client: Client, { channelToken }: StatusArgs): AsyncHttpResponse<StatusResponse> => {
+  return get(client, path, { authToken: channelToken });
+};

--- a/packages/connect/src/clients/createAppClient.test.ts
+++ b/packages/connect/src/clients/createAppClient.test.ts
@@ -1,0 +1,37 @@
+import { createAppClient, AppClient } from "./createAppClient";
+
+describe("createAppClient", () => {
+  const config = {
+    relayURI: "https://connect.farcaster.xyz",
+  };
+
+  let appClient: AppClient;
+
+  beforeEach(() => {
+    appClient = createAppClient(config);
+  });
+
+  test("adds version to config", () => {
+    expect(appClient.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v1",
+    });
+  });
+
+  test("overrides version", () => {
+    appClient = createAppClient({
+      ...config,
+      version: "v2",
+    });
+
+    expect(appClient.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v2",
+    });
+  });
+
+  test("includes app actions", () => {
+    expect(appClient.connect).toBeDefined();
+    expect(appClient.status).toBeDefined();
+  });
+});

--- a/packages/connect/src/clients/createAppClient.ts
+++ b/packages/connect/src/clients/createAppClient.ts
@@ -1,0 +1,18 @@
+import { connect, ConnectArgs, ConnectResponse } from "../actions/connect";
+import { status, StatusArgs, StatusResponse } from "../actions/status";
+import { Client, ClientConfig, createClient } from "./createClient";
+import { AsyncHttpResponse } from "./transports/http";
+
+export interface AppClient extends Client {
+  connect: (args: ConnectArgs) => AsyncHttpResponse<ConnectResponse>;
+  status: (args: StatusArgs) => AsyncHttpResponse<StatusResponse>;
+}
+
+export const createAppClient = (config: ClientConfig): AppClient => {
+  const client = createClient(config);
+  return {
+    ...client,
+    connect: (args: ConnectArgs) => connect(client, args),
+    status: (args: StatusArgs) => status(client, args),
+  };
+};

--- a/packages/connect/src/clients/createClient.test.ts
+++ b/packages/connect/src/clients/createClient.test.ts
@@ -1,0 +1,46 @@
+import { createClient, Client } from "./createClient";
+
+describe("createClient", () => {
+  const config = {
+    relayURI: "https://connect.farcaster.xyz",
+  };
+
+  let client: Client;
+
+  beforeEach(() => {
+    client = createClient(config);
+  });
+
+  test("adds version to config", () => {
+    expect(client.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v1",
+    });
+  });
+
+  test("overrides version", () => {
+    client = createClient({
+      ...config,
+      version: "v2",
+    });
+
+    expect(client.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v2",
+    });
+  });
+
+  test("includes no actions", () => {
+    client = createClient({
+      ...config,
+      version: "v2",
+    });
+
+    expect(client).toEqual({
+      config: {
+        relayURI: "https://connect.farcaster.xyz",
+        version: "v2",
+      },
+    });
+  });
+});

--- a/packages/connect/src/clients/createClient.ts
+++ b/packages/connect/src/clients/createClient.ts
@@ -1,0 +1,18 @@
+export interface ClientConfig {
+  relayURI: string;
+  version?: string;
+}
+
+export interface Client {
+  config: ClientConfig;
+}
+
+const configDefaults = {
+  version: "v1",
+};
+
+export const createClient = (config: ClientConfig) => {
+  return {
+    config: { ...configDefaults, ...config },
+  };
+};

--- a/packages/connect/src/clients/createWalletClient.test.ts
+++ b/packages/connect/src/clients/createWalletClient.test.ts
@@ -1,0 +1,36 @@
+import { createWalletClient, WalletClient } from "./createWalletClient";
+
+describe("createWalletClient", () => {
+  const config = {
+    relayURI: "https://connect.farcaster.xyz",
+  };
+
+  let walletClient: WalletClient;
+
+  beforeEach(() => {
+    walletClient = createWalletClient(config);
+  });
+
+  test("adds version to config", () => {
+    expect(walletClient.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v1",
+    });
+  });
+
+  test("overrides version", () => {
+    walletClient = createWalletClient({
+      ...config,
+      version: "v2",
+    });
+
+    expect(walletClient.config).toEqual({
+      relayURI: "https://connect.farcaster.xyz",
+      version: "v2",
+    });
+  });
+
+  test("includes app actions", () => {
+    expect(walletClient.authenticate).toBeDefined();
+  });
+});

--- a/packages/connect/src/clients/createWalletClient.ts
+++ b/packages/connect/src/clients/createWalletClient.ts
@@ -1,0 +1,15 @@
+import { authenticate, AuthenticateArgs, AuthenticateResponse } from "../actions/authenticate";
+import { Client, ClientConfig, createClient } from "./createClient";
+import { AsyncHttpResponse } from "./transports/http";
+
+export interface WalletClient extends Client {
+  authenticate: (args: AuthenticateArgs) => AsyncHttpResponse<AuthenticateResponse>;
+}
+
+export const createWalletClient = (config: ClientConfig): WalletClient => {
+  const client = createClient(config);
+  return {
+    ...client,
+    authenticate: (args: AuthenticateArgs) => authenticate(client, args),
+  };
+};

--- a/packages/connect/src/clients/index.ts
+++ b/packages/connect/src/clients/index.ts
@@ -1,0 +1,13 @@
+export { createAppClient } from "./createAppClient";
+export { createWalletClient } from "./createWalletClient";
+
+export type { AppClient } from "./createAppClient";
+export type { WalletClient } from "./createWalletClient";
+export type { ClientConfig } from "./createClient";
+export type { ConnectArgs, ConnectResponse } from "../actions/connect";
+export type { StatusArgs, StatusResponse } from "../actions/status";
+export type {
+  AuthenticateArgs,
+  AuthenticateResponse,
+} from "../actions/authenticate";
+export type { AsyncHttpResponse, HttpResponse } from "./transports/http";

--- a/packages/connect/src/clients/transports/http.test.ts
+++ b/packages/connect/src/clients/transports/http.test.ts
@@ -1,0 +1,110 @@
+import { createClient } from "../createClient";
+import { get, post } from "./http";
+import { jest } from "@jest/globals";
+
+describe("http", () => {
+  const config = {
+    relayURI: "https://connect.farcaster.xyz",
+  };
+
+  const client = createClient(config);
+
+  const data = { data: "response stub" };
+  let response: Response;
+
+  beforeEach(() => {
+    response = new Response(JSON.stringify(data));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("get", () => {
+    test("returns fetch response", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      const res = await get(client, "path");
+
+      expect(res.response).toEqual(response);
+    });
+
+    test("returns parsed body data", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      const res = await get(client, "path");
+
+      expect(res.data).toEqual(data);
+    });
+
+    test("constructs fetch request", async () => {
+      const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      await get(client, "path");
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/path", {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    test("adds optional params", async () => {
+      const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      await get(client, "path", {
+        authToken: "some-auth-token",
+        headers: { "X-Some-Header": "some-header-value" },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/path", {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer some-auth-token",
+          "X-Some-Header": "some-header-value",
+        },
+      });
+    });
+  });
+
+  describe("post", () => {
+    test("returns fetch response", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      const requestData = { data: "request stub" };
+      const res = await post(client, "path", requestData);
+
+      expect(res.response).toEqual(response);
+    });
+
+    test("returns parsed body data", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      const requestData = { data: "request stub" };
+      const res = await post(client, "path", requestData);
+
+      expect(res.data).toEqual(data);
+    });
+
+    test("constructs fetch request", async () => {
+      const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
+
+      const requestData = { data: "request stub" };
+      await post(client, "path", requestData, {
+        authToken: "some-auth-token",
+        headers: { "X-Some-Header": "some-header-value" },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("https://connect.farcaster.xyz/v1/path", {
+        method: "POST",
+        body: JSON.stringify(requestData),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer some-auth-token",
+          "X-Some-Header": "some-header-value",
+        },
+      });
+    });
+  });
+});

--- a/packages/connect/src/clients/transports/http.ts
+++ b/packages/connect/src/clients/transports/http.ts
@@ -1,0 +1,54 @@
+import { Client } from "../createClient";
+
+export interface HttpOpts {
+  authToken?: string;
+  headers?: Record<string, string>;
+}
+
+export interface HttpResponse<ResponseDataType> {
+  response: Response;
+  data: ResponseDataType;
+}
+
+export type AsyncHttpResponse<T> = Promise<HttpResponse<T>>;
+
+export const get = async <ResponseDataType>(
+  client: Client,
+  path: string,
+  opts?: HttpOpts,
+): Promise<HttpResponse<ResponseDataType>> => {
+  const response = await fetch(getURI(client, path), {
+    headers: getHeaders(opts),
+  });
+  const data: ResponseDataType = await response.json();
+  return { response, data };
+};
+
+export const post = async <BodyType, ResponseDataType>(
+  client: Client,
+  path: string,
+  json: BodyType,
+  opts?: HttpOpts,
+): Promise<HttpResponse<ResponseDataType>> => {
+  const response = await fetch(getURI(client, path), {
+    method: "POST",
+    body: JSON.stringify(json),
+    headers: getHeaders(opts),
+  });
+  const data: ResponseDataType = await response.json();
+  return { response, data };
+};
+
+const getURI = (client: Client, path: string) => {
+  return `${client.config.relayURI}/${client.config.version}/${path}`;
+};
+
+const getHeaders = (opts?: HttpOpts) => {
+  const headers = {
+    ...opts?.headers,
+  };
+  if (opts?.authToken) {
+    headers["Authorization"] = `Bearer ${opts.authToken}`;
+  }
+  return { ...headers, "Content-Type": "application/json" };
+};

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./errors";
 export * from "./messages";
+export * from "./clients";


### PR DESCRIPTION
## Motivation

Developers should be able to easily use connect without depending on a particular frontend UI like React.

## Change Summary

Add client module to connect package. Use `AppClient` for frontend app actions (creating a connect channel and reading status), and `WalletClient` for wallet apps like Warpcast handling SIWE signing. 

We can continue building on this scaffolding as we build out the client library.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

Although we'll only have a handful of actions, we're trying to create a Viem-like developer interface: 

```ts
import { createAppClient } from "@farcaster/connect";

const client = createAppClient({
    relayURI: "https://connect.farcaster.xyz"
});

const { data: { channelToken } } = await client.connect({
    siweUri: "https://example.com/login",
    doman: "example.com"
});
const { data: { state } } = await client.status({ channelToken });
```