### PR TITLE
refactor: rename wallet client

### DIFF
--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -9,7 +9,7 @@
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/",
     "test": "yarn build && jest",
-    "test:ci": "yarn build && ENVIRONMENT=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest --ci --forceExit --coverage",
+    "test:ci": "yarn build && ENVIRONMENT=test NODE_OPTIONS=\"--max-old-space-size=4096\" jest --ci --forceExit --coverage",
     "start": "yarn build && node build/app.js start"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "packageManager": "yarn@1.22.19",
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "test/*"
   ],
   "scripts": {
     "build": "./node_modules/.bin/turbo run build",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -20,8 +20,8 @@
     "clean": "rimraf ./dist",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage",
+    "test": "jest",
+    "test:ci": "ENVIRONMENT=test jest --ci --forceExit --coverage",
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {

--- a/packages/connect/src/actions/authenticate.test.ts
+++ b/packages/connect/src/actions/authenticate.test.ts
@@ -1,8 +1,8 @@
-import { createWalletClient } from "../clients/createWalletClient";
+import { createAuthClient } from "../clients/createAuthClient";
 import { jest } from "@jest/globals";
 
 describe("authenticate", () => {
-  const client = createWalletClient({
+  const client = createAuthClient({
     relayURI: "https://connect.farcaster.xyz",
   });
 

--- a/packages/connect/src/clients/createAuthClient.test.ts
+++ b/packages/connect/src/clients/createAuthClient.test.ts
@@ -1,36 +1,36 @@
-import { createWalletClient, WalletClient } from "./createWalletClient";
+import { createAuthClient, AuthClient } from "./createAuthClient";
 
-describe("createWalletClient", () => {
+describe("createAuthClient", () => {
   const config = {
     relayURI: "https://connect.farcaster.xyz",
   };
 
-  let walletClient: WalletClient;
+  let authClient: AuthClient;
 
   beforeEach(() => {
-    walletClient = createWalletClient(config);
+    authClient = createAuthClient(config);
   });
 
   test("adds version to config", () => {
-    expect(walletClient.config).toEqual({
+    expect(authClient.config).toEqual({
       relayURI: "https://connect.farcaster.xyz",
       version: "v1",
     });
   });
 
   test("overrides version", () => {
-    walletClient = createWalletClient({
+    authClient = createAuthClient({
       ...config,
       version: "v2",
     });
 
-    expect(walletClient.config).toEqual({
+    expect(authClient.config).toEqual({
       relayURI: "https://connect.farcaster.xyz",
       version: "v2",
     });
   });
 
   test("includes app actions", () => {
-    expect(walletClient.authenticate).toBeDefined();
+    expect(authClient.authenticate).toBeDefined();
   });
 });

--- a/packages/connect/src/clients/createAuthClient.ts
+++ b/packages/connect/src/clients/createAuthClient.ts
@@ -2,11 +2,11 @@ import { authenticate, AuthenticateArgs, AuthenticateResponse } from "../actions
 import { Client, ClientConfig, createClient } from "./createClient";
 import { AsyncHttpResponse } from "./transports/http";
 
-export interface WalletClient extends Client {
+export interface AuthClient extends Client {
   authenticate: (args: AuthenticateArgs) => AsyncHttpResponse<AuthenticateResponse>;
 }
 
-export const createWalletClient = (config: ClientConfig): WalletClient => {
+export const createAuthClient = (config: ClientConfig): AuthClient => {
   const client = createClient(config);
   return {
     ...client,

--- a/packages/connect/src/clients/index.ts
+++ b/packages/connect/src/clients/index.ts
@@ -1,8 +1,8 @@
 export { createAppClient } from "./createAppClient";
-export { createWalletClient } from "./createWalletClient";
+export { createAuthClient } from "./createAuthClient";
 
 export type { AppClient } from "./createAppClient";
-export type { WalletClient } from "./createWalletClient";
+export type { AuthClient } from "./createAuthClient";
 export type { ClientConfig } from "./createClient";
 export type { ConnectArgs, ConnectResponse } from "../actions/connect";
 export type { StatusArgs, StatusResponse } from "../actions/status";

--- a/test/client/biome.json
+++ b/test/client/biome.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "organizeImports": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentSize": 2,
+    "indentStyle": "space",
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off"
+      }
+    }
+  }
+}

--- a/test/client/jest.config.ts
+++ b/test/client/jest.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "jest";
+
+const jestConfig: Config = {
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^~/(.*)$": "<rootDir>/src/$1",
+    "^(.+)_generated.js$": "$1_generated", // Support flatc generated files
+  },
+  coveragePathIgnorePatterns: ["<rootDir>/build/", "<rootDir>/node_modules/"],
+  testPathIgnorePatterns: ["<rootDir>/build", "<rootDir>/node_modules"],
+  extensionsToTreatAsEsm: [".ts"],
+  /**
+   * For high performance with minimal configuration transform with TS with swc.
+   * @see https://github.com/farcasterxyz/hubble/issues/314
+   */
+  transform: {
+    "^.+\\.(t|j)sx?$": "@swc/jest",
+  },
+};
+
+export default jestConfig;

--- a/test/client/package.json
+++ b/test/client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "client-test",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "test:ci": "ENVIRONMENT=test jest --ci --forceExit --coverage",
+    "lint": "biome format src/ --write && biome check src/ --apply",
+    "lint:ci": "biome ci src/"
+  }
+}

--- a/test/client/src/e2e.test.ts
+++ b/test/client/src/e2e.test.ts
@@ -1,0 +1,93 @@
+import { RelayServer } from "../../../apps/relay/src/server";
+import { createAppClient, createAuthClient } from "../../../packages/connect/src/clients";
+import { jest } from "@jest/globals";
+
+let httpServer: RelayServer;
+let httpServerAddress: string;
+
+beforeAll(async () => {
+  httpServer = new RelayServer({
+    redisUrl: "redis://localhost:6379",
+    ttl: 3600,
+    corsOrigin: "*",
+  });
+  httpServerAddress = (await httpServer.start())._unsafeUnwrap();
+});
+
+afterAll(async () => {
+  await httpServer.stop();
+});
+
+afterEach(async () => {
+  await httpServer.channels.clear();
+  jest.restoreAllMocks();
+});
+
+describe("clients", () => {
+  const connectParams = {
+    siweUri: "https://example.com",
+    domain: "example.com",
+  };
+
+  const authenticateParams = {
+    message: "example.com wants you to sign in with your Ethereum account: [...]",
+    signature:
+      "0x9335c30585854d1bd7040dccfbb18bfecc9eba6ee18c55a3996ef0aca783fba832b13b05dc09beec99fc6477804113fd293c68c84ea350a11794cdc121c71fd51b" as const,
+    fid: 1,
+    username: "alice",
+    bio: "I'm a little teapot who didn't fill out my bio",
+    displayName: "Alice Teapot",
+    pfpUrl: "https://example.com/alice.png",
+  };
+
+  describe("e2e", () => {
+    test("end to end connect flow", async () => {
+      const appClient = createAppClient({
+        relayURI: httpServerAddress,
+      });
+
+      const authClient = createAuthClient({
+        relayURI: httpServerAddress,
+      });
+
+      const customNonce = "some-custom-nonce";
+      const {
+        response: connectResponse,
+        data: { channelToken },
+      } = await appClient.connect({ ...connectParams, nonce: customNonce });
+
+      expect(connectResponse.status).toBe(201);
+
+      const {
+        response: pendingStatusResponse,
+        data: { state: pendingState },
+      } = await appClient.status({ channelToken });
+
+      expect(pendingStatusResponse.status).toBe(200);
+      expect(pendingState).toBe("pending");
+
+      const { response: authResponse } = await authClient.authenticate({
+        channelToken,
+        ...authenticateParams,
+      });
+      expect(authResponse.status).toBe(200);
+
+      const {
+        response: completedStatusResponse,
+        data: { state: completedState, message, signature, nonce },
+      } = await appClient.status({ channelToken });
+
+      expect(completedStatusResponse.status).toBe(200);
+      expect(completedState).toBe("completed");
+      expect(message).toBe(authenticateParams.message);
+      expect(signature).toBe(authenticateParams.signature);
+      expect(nonce).toBe(nonce);
+
+      const { response: channelClosedResponse } = await appClient.status({
+        channelToken,
+      });
+
+      expect(channelClosedResponse.status).toBe(401);
+    });
+  });
+});

--- a/test/client/tsconfig.json
+++ b/test/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "declaration": true,
+      "baseUrl": "./src",
+      "outDir": "build",
+      "rootDir": "src",
+      "isolatedModules": true
+    },
+    "include": ["src/index.ts"],
+    "exclude": ["build", "node_modules", "jest.config.ts"]
+  }


### PR DESCRIPTION
## Motivation

`WalletClient` is a confusing name, since it shadows the same name in Viem. Let's call this `AuthClient` instead.

## Change Summary

- Rename `WalletClient` to `AuthClient`.
- Add e2e client test package

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed