### PR TITLE
feat: parse sign in URI

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -25,6 +25,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@farcaster/hub-web": "^0.7.1",
     "siwe": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/connect/src/actions/app/connect.test.ts
+++ b/packages/connect/src/actions/app/connect.test.ts
@@ -1,9 +1,11 @@
 import { createAppClient } from "../../clients/createAppClient";
 import { jest } from "@jest/globals";
+import { viem } from "../../clients/ethereum/viem";
 
 describe("connect", () => {
   const client = createAppClient({
     relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
   });
 
   afterEach(() => {

--- a/packages/connect/src/actions/app/status.test.ts
+++ b/packages/connect/src/actions/app/status.test.ts
@@ -1,9 +1,11 @@
 import { createAppClient } from "../../clients/createAppClient";
 import { jest } from "@jest/globals";
+import { viem } from "../../clients/ethereum/viem";
 
 describe("status", () => {
   const client = createAppClient({
     relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
   });
 
   afterEach(() => {

--- a/packages/connect/src/actions/app/verifySignInMessage.test.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.test.ts
@@ -1,0 +1,48 @@
+import { createAppClient } from "../../clients/createAppClient";
+import { createAuthClient } from "../../clients/createAuthClient";
+import { viem } from "../../clients/ethereum/viem";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import { ConnectError } from "../../errors";
+
+describe("verifySignInMessage", () => {
+  const client = createAppClient({
+    relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
+  });
+
+  const authClient = createAuthClient({
+    relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
+  });
+
+  const account = privateKeyToAccount(generatePrivateKey());
+
+  const siweParams = {
+    domain: "example.com",
+    uri: "https://example.com/login",
+    version: "1",
+    issuedAt: "2023-10-01T00:00:00.000Z",
+  };
+
+  test("verifies sign in message", async () => {
+    const message = authClient.buildSignInMessage({
+      ...siweParams,
+      address: account.address,
+      fid: 1234,
+    });
+
+    const signature = await account.signMessage({
+      message: message.toMessage(),
+    });
+
+    const errMsg = `Invalid resource: signer ${account.address} does not own fid 1234.`;
+    const error = new ConnectError("unauthorized", errMsg);
+
+    await expect(
+      client.verifySignInMessage({
+        message,
+        signature,
+      }),
+    ).rejects.toStrictEqual(error);
+  });
+});

--- a/packages/connect/src/actions/app/verifySignInMessage.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.ts
@@ -1,18 +1,21 @@
+import { SiweMessage } from "siwe";
 import { Client } from "../../clients/createClient";
 import { SignInResponse, verify } from "../../messages/verify";
 
 export interface VerifySignInMessageArgs {
-  message: string;
+  message: string | Partial<SiweMessage>;
   signature: `0x${string}`;
 }
 
 export type VerifySignInMessageResponse = Promise<SignInResponse>;
 
 export const verifySignInMessage = async (
-  _client: Client,
+  client: Client,
   { message, signature }: VerifySignInMessageArgs,
 ): VerifySignInMessageResponse => {
-  const result = await verify(message, signature);
+  const result = await verify(message, signature, {
+    getFid: client.ethereum.getFid,
+  });
   if (result.isErr()) {
     throw result.error;
   } else {

--- a/packages/connect/src/actions/auth/authenticate.test.ts
+++ b/packages/connect/src/actions/auth/authenticate.test.ts
@@ -1,9 +1,11 @@
 import { createAuthClient } from "../../clients/createAuthClient";
 import { jest } from "@jest/globals";
+import { viem } from "../../clients/ethereum/viem";
 
 describe("authenticate", () => {
   const client = createAuthClient({
     relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
   });
 
   afterEach(() => {

--- a/packages/connect/src/actions/auth/buildSignInMessage.test.ts
+++ b/packages/connect/src/actions/auth/buildSignInMessage.test.ts
@@ -1,0 +1,31 @@
+import { createAuthClient } from "../../clients/createAuthClient";
+import { viem } from "../../clients/ethereum/viem";
+
+describe("buildSignInMessage", () => {
+  const client = createAuthClient({
+    relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
+  });
+
+  test("builds Siwe message from provided parameters", async () => {
+    const message = client.buildSignInMessage({
+      address: "0x63C378DDC446DFf1d831B9B96F7d338FE6bd4231",
+      uri: "https://example.com/login",
+      domain: "example.com",
+      nonce: "12345678",
+      fid: 1,
+      resources: ["https://example.com/resource"],
+    });
+
+    expect(message).toMatchObject({
+      address: "0x63C378DDC446DFf1d831B9B96F7d338FE6bd4231",
+      statement: "Farcaster Connect",
+      chainId: 10,
+      uri: "https://example.com/login",
+      domain: "example.com",
+      version: "1",
+      nonce: "12345678",
+      resources: ["farcaster://fid/1", "https://example.com/resource"],
+    });
+  });
+});

--- a/packages/connect/src/actions/auth/parseSignInURI.test.ts
+++ b/packages/connect/src/actions/auth/parseSignInURI.test.ts
@@ -1,0 +1,22 @@
+import { createAuthClient } from "../../clients/createAuthClient";
+import { viem } from "../../clients/ethereum/viem";
+
+describe("parseSignInURI", () => {
+  const client = createAuthClient({
+    relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
+  });
+
+  test("parses sign in params from protocol URI", async () => {
+    const { channelToken, params } = client.parseSignInURI({
+      uri: "farcaster://connect?channelToken=76be6229-bdf7-4ad2-930a-540fb2de1e08&nonce=ESsxs6MaFio7OvqWb&siweUri=https%3A%2F%2Fexample.com%2Flogin&domain=example.com",
+    });
+
+    expect(channelToken).toBe("76be6229-bdf7-4ad2-930a-540fb2de1e08");
+    expect(params).toStrictEqual({
+      domain: "example.com",
+      siweUri: "https://example.com/login",
+      nonce: "ESsxs6MaFio7OvqWb",
+    });
+  });
+});

--- a/packages/connect/src/actions/auth/parseSignInURI.ts
+++ b/packages/connect/src/actions/auth/parseSignInURI.ts
@@ -1,0 +1,16 @@
+import { Client } from "../../clients/createClient";
+import { parseSignInURI as parse, ParsedSignInURI } from "../../messages/parseSignInURI";
+
+export interface ParseSignInURIArgs {
+  uri: string;
+}
+export type ParseSignInURIResponse = ParsedSignInURI;
+
+export const parseSignInURI = (_client: Client, { uri }: ParseSignInURIArgs): ParseSignInURIResponse => {
+  const result = parse(uri);
+  if (result.isErr()) {
+    throw result.error;
+  } else {
+    return result.value;
+  }
+};

--- a/packages/connect/src/clients/createAppClient.test.ts
+++ b/packages/connect/src/clients/createAppClient.test.ts
@@ -1,8 +1,10 @@
 import { createAppClient, AppClient } from "./createAppClient";
+import { viem } from "./ethereum/viem";
 
 describe("createAppClient", () => {
   const config = {
     relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
   };
 
   let appClient: AppClient;

--- a/packages/connect/src/clients/createAppClient.ts
+++ b/packages/connect/src/clients/createAppClient.ts
@@ -5,7 +5,7 @@ import {
   VerifySignInMessageArgs,
   VerifySignInMessageResponse,
 } from "../actions/app/verifySignInMessage";
-import { Client, ClientConfig, createClient } from "./createClient";
+import { Client, CreateClientArgs, createClient } from "./createClient";
 
 export interface AppClient extends Client {
   connect: (args: ConnectArgs) => ConnectResponse;
@@ -13,7 +13,7 @@ export interface AppClient extends Client {
   verifySignInMessage: (args: VerifySignInMessageArgs) => VerifySignInMessageResponse;
 }
 
-export const createAppClient = (config: ClientConfig): AppClient => {
+export const createAppClient = (config: CreateClientArgs): AppClient => {
   const client = createClient(config);
   return {
     ...client,

--- a/packages/connect/src/clients/createAuthClient.test.ts
+++ b/packages/connect/src/clients/createAuthClient.test.ts
@@ -1,8 +1,10 @@
 import { createAuthClient, AuthClient } from "./createAuthClient";
+import { viem } from "./ethereum/viem";
 
 describe("createAuthClient", () => {
   const config = {
     relayURI: "https://connect.farcaster.xyz",
+    ethereum: viem(),
   };
 
   let authClient: AuthClient;

--- a/packages/connect/src/clients/createAuthClient.ts
+++ b/packages/connect/src/clients/createAuthClient.ts
@@ -1,21 +1,24 @@
 import { authenticate, AuthenticateArgs, AuthenticateResponse } from "../actions/auth/authenticate";
+import { parseSignInURI, ParseSignInURIArgs, ParseSignInURIResponse } from "../actions/auth/parseSignInURI";
 import {
   buildSignInMessage,
   BuildSignInMessageArgs,
   BuildSignInMessageResponse,
 } from "../actions/auth/buildSignInMessage";
-import { Client, ClientConfig, createClient } from "./createClient";
+import { Client, CreateClientArgs, createClient } from "./createClient";
 
 export interface AuthClient extends Client {
   authenticate: (args: AuthenticateArgs) => AuthenticateResponse;
   buildSignInMessage: (args: BuildSignInMessageArgs) => BuildSignInMessageResponse;
+  parseSignInURI: (args: ParseSignInURIArgs) => ParseSignInURIResponse;
 }
 
-export const createAuthClient = (config: ClientConfig): AuthClient => {
+export const createAuthClient = (config: CreateClientArgs): AuthClient => {
   const client = createClient(config);
   return {
     ...client,
     authenticate: (args: AuthenticateArgs) => authenticate(client, args),
     buildSignInMessage: (args: BuildSignInMessageArgs) => buildSignInMessage(client, args),
+    parseSignInURI: (args: ParseSignInURIArgs) => parseSignInURI(client, args),
   };
 };

--- a/packages/connect/src/clients/createClient.ts
+++ b/packages/connect/src/clients/createClient.ts
@@ -1,3 +1,11 @@
+import { Ethereum } from "../clients/ethereum/viem";
+
+export interface CreateClientArgs {
+  relayURI: string;
+  version?: string;
+  ethereum: Ethereum;
+}
+
 export interface ClientConfig {
   relayURI: string;
   version?: string;
@@ -5,14 +13,16 @@ export interface ClientConfig {
 
 export interface Client {
   config: ClientConfig;
+  ethereum: Ethereum;
 }
 
 const configDefaults = {
   version: "v1",
 };
 
-export const createClient = (config: ClientConfig) => {
+export const createClient = ({ ethereum, ...config }: CreateClientArgs) => {
   return {
     config: { ...configDefaults, ...config },
+    ethereum: ethereum,
   };
 };

--- a/packages/connect/src/clients/ethereum/viem.ts
+++ b/packages/connect/src/clients/ethereum/viem.ts
@@ -1,0 +1,31 @@
+import { Hex, createPublicClient, http } from "viem";
+import { optimism } from "viem/chains";
+import { ID_REGISTRY_ADDRESS, idRegistryABI } from "@farcaster/hub-web";
+
+export interface Ethereum {
+  getFid: (custody: Hex) => Promise<BigInt>;
+}
+
+interface ViemConfigArgs {
+  rpcUrl?: string;
+}
+
+export const viem = (args?: ViemConfigArgs): Ethereum => {
+  const publicClient = createPublicClient({
+    chain: optimism,
+    transport: http(args?.rpcUrl),
+  });
+
+  const getFid = async (custody: Hex): Promise<BigInt> => {
+    return publicClient.readContract({
+      address: ID_REGISTRY_ADDRESS,
+      abi: idRegistryABI,
+      functionName: "idOf",
+      args: [custody],
+    });
+  };
+
+  return {
+    getFid,
+  };
+};

--- a/packages/connect/src/messages/build.ts
+++ b/packages/connect/src/messages/build.ts
@@ -12,6 +12,7 @@ export type SignInMessageParams = Partial<SiweMessage> & FarcasterResourceParams
 export const build = (params: SignInMessageParams): ConnectResult<SiweMessage> => {
   const { fid, ...siweParams } = params;
   const resources = siweParams.resources ?? [];
+  siweParams.version = "1";
   siweParams.statement = STATEMENT;
   siweParams.chainId = CHAIN_ID;
   siweParams.resources = [buildFidResource(fid), ...resources];

--- a/packages/connect/src/messages/build.ts
+++ b/packages/connect/src/messages/build.ts
@@ -1,6 +1,7 @@
 import { SiweMessage } from "siwe";
 import { ConnectResult } from "../errors";
 import { validate } from "./validate";
+import { parseSignInURI } from "./parseSignInURI";
 import { STATEMENT, CHAIN_ID } from "./constants";
 
 export type FarcasterResourceParams = {
@@ -15,6 +16,10 @@ export const build = (params: SignInMessageParams): ConnectResult<SiweMessage> =
   siweParams.chainId = CHAIN_ID;
   siweParams.resources = [buildFidResource(fid), ...resources];
   return validate(siweParams);
+};
+
+export const buildFromSignInURI = (signInUri: string, fid: number): ConnectResult<SiweMessage> => {
+  return parseSignInURI(signInUri).andThen(({ params }) => build({ ...params, fid }));
 };
 
 const buildFidResource = (fid: number): string => {

--- a/packages/connect/src/messages/parseSignInURI.test.ts
+++ b/packages/connect/src/messages/parseSignInURI.test.ts
@@ -1,0 +1,17 @@
+import { parseSignInURI } from "./parseSignInURI";
+
+describe("parseSignInUri", () => {
+  test("parses protocol handler URI into message params", () => {
+    const signInUri =
+      "farcaster://connect?channelToken=76be6229-bdf7-4ad2-930a-540fb2de1e08&nonce=ESsxs6MaFio7OvqWb&siweUri=https%3A%2F%2Fexample.com%2Flogin&domain=example.com";
+    const result = parseSignInURI(signInUri);
+    expect(result._unsafeUnwrap()).toStrictEqual({
+      channelToken: "76be6229-bdf7-4ad2-930a-540fb2de1e08",
+      params: {
+        domain: "example.com",
+        siweUri: "https://example.com/login",
+        nonce: "ESsxs6MaFio7OvqWb",
+      },
+    });
+  });
+});

--- a/packages/connect/src/messages/parseSignInURI.ts
+++ b/packages/connect/src/messages/parseSignInURI.ts
@@ -4,7 +4,7 @@ import { SignInMessageParams } from "./build";
 
 export interface ParsedSignInURI {
   channelToken: string;
-  params: Partial<SignInMessageParams>;
+  params: Partial<SignInMessageParams> & { siweUri?: string };
 }
 
 export const parseSignInURI = (signInUri: string): ConnectResult<ParsedSignInURI> => {

--- a/packages/connect/src/messages/parseSignInURI.ts
+++ b/packages/connect/src/messages/parseSignInURI.ts
@@ -1,0 +1,31 @@
+import { err, ok } from "neverthrow";
+import { ConnectError, ConnectResult } from "../errors";
+import { SignInMessageParams } from "./build";
+
+export interface ParsedSignInURI {
+  channelToken: string;
+  params: Partial<SignInMessageParams>;
+}
+
+export const parseSignInURI = (signInUri: string): ConnectResult<ParsedSignInURI> => {
+  const url = new URL(signInUri);
+  const searchParams = Object.fromEntries(url.searchParams.entries());
+  const { channelToken, ...params } = searchParams;
+  if (!channelToken) {
+    return err(validationFail("No channel token provided"));
+  }
+  if (!params["nonce"]) {
+    return err(validationFail("No nonce provided"));
+  }
+  if (!params["siweUri"]) {
+    return err(validationFail("No SIWE URI provided"));
+  }
+  if (!params["domain"]) {
+    return err(validationFail("No domain provided"));
+  }
+  return ok({ channelToken, params });
+};
+
+const validationFail = (message: string): ConnectError => {
+  return new ConnectError("bad_request.validation_failure", message);
+};

--- a/packages/connect/src/messages/verify.ts
+++ b/packages/connect/src/messages/verify.ts
@@ -8,7 +8,7 @@ import { FarcasterResourceParams } from "./build";
 
 type Hex = `0x${string}`;
 type SignInOpts = {
-  verifyFid: (custody: Hex) => Promise<BigInt>;
+  getFid: (custody: Hex) => Promise<BigInt>;
   provider?: Provider;
 };
 export type SignInResponse = SiweResponse & FarcasterResourceParams;
@@ -23,10 +23,10 @@ export const verify = async (
   message: string | Partial<SiweMessage>,
   signature: string,
   options: SignInOpts = {
-    verifyFid: voidVerifyFid,
+    getFid: voidVerifyFid,
   },
 ): ConnectAsyncResult<SignInResponse> => {
-  const { verifyFid, provider } = options;
+  const { getFid, provider } = options;
   const valid = validate(message);
   if (valid.isErr()) return err(valid.error);
 
@@ -37,7 +37,7 @@ export const verify = async (
     return err(new ConnectError("unauthorized", errMessage));
   }
 
-  const fid = await verifyFidOwner(siwe.value, verifyFid);
+  const fid = await verifyFidOwner(siwe.value, getFid);
   if (fid.isErr()) return err(fid.error);
   if (!fid.value.success) {
     const errMessage = siwe.value.error?.type ?? "Unknown error";

--- a/test/client/package.json
+++ b/test/client/package.json
@@ -7,5 +7,8 @@
     "test:ci": "ENVIRONMENT=test jest --ci --forceExit --coverage",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/"
+  },
+  "devDependencies": {
+    "viem": "^1.20.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,7 +667,7 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz#c8285183dbdb17008578dbacb6e22748709b4822"
   integrity sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==
 
-"@farcaster/core@0.13.3":
+"@farcaster/core@0.13.3", "@farcaster/core@^0.13.2":
   version "0.13.3"
   resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.13.3.tgz#8830d6b70f4d3c7a1dc4ea1bbfa7cf2ad92e9c6a"
   integrity sha512-OI2ml+QKst9fwvpqJsmSqgK3goPsXkFU6AGmeuFuNAyGPQaRRB4MBS2YHQLkFpSZZ5bS82ENcx2CKAwTfh5Rwg==
@@ -688,6 +688,15 @@
     "@grpc/grpc-js" "~1.8.21"
     "@noble/hashes" "^1.3.0"
     neverthrow "^6.0.0"
+
+"@farcaster/hub-web@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.npmjs.org/@farcaster/hub-web/-/hub-web-0.7.1.tgz#cf1fe6a8f40a91f459311951a503c854d23a2a0f"
+  integrity sha512-cBcbfdWlM00tXxcKnoSVGiqvjqt/AEC9yQYDmbZnE6PoP1TzdA2ez/rrRuKswC90KB5JQVJLbPt+lb+azGmFyw==
+  dependencies:
+    "@farcaster/core" "^0.13.2"
+    "@improbable-eng/grpc-web" "^0.15.0"
+    rxjs "^7.8.0"
 
 "@fastify/ajv-compiler@^3.5.0":
   version "3.5.0"
@@ -749,6 +758,13 @@
     long "^5.0.0"
     protobufjs "^7.2.4"
     yargs "^17.7.2"
+
+"@improbable-eng/grpc-web@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz#3e47e9fdd90381a74abd4b7d26e67422a2a04bef"
+  integrity sha512-ERft9/0/8CmYalqOVnJnpdDry28q+j+nAlFFARdjyxXDJ+Mhgv9+F600QC8BR9ygOfrXRlAk6CvST2j+JCpQPg==
+  dependencies:
+    browser-headers "^0.4.1"
 
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
@@ -1934,6 +1950,11 @@ breakword@^1.0.5:
   integrity sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==
   dependencies:
     wcwidth "^1.0.1"
+
+browser-headers@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz#4308a7ad3b240f4203dbb45acedb38dc2d65dd02"
+  integrity sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==
 
 browserslist@^4.21.9:
   version "4.22.2"
@@ -5002,6 +5023,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.8.0:
+  version "7.8.1"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
@@ -5608,6 +5636,11 @@ tslib@2.4.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.1.0:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tsup@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/tsup/-/tsup-8.0.1.tgz#04a0170f7bbe77e81da3b53006b0a40282291833"
@@ -5828,6 +5861,20 @@ viem@^1.12.2, viem@^1.19.11:
   version "1.19.11"
   resolved "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz#de4ee7537ee036894bd818aa316a8faecaf017e9"
   integrity sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@scure/bip32" "1.3.2"
+    "@scure/bip39" "1.2.1"
+    abitype "0.9.8"
+    isows "1.0.3"
+    ws "8.13.0"
+
+viem@^1.20.3:
+  version "1.20.3"
+  resolved "https://registry.npmjs.org/viem/-/viem-1.20.3.tgz#8b8360daee622295f5385949c02c86d943d14e0f"
+  integrity sha512-7CrmeCb2KYkeCgUmUyb1hsf+IX/PLwi+Np+Vm4YUTPeG82y3HRSgGHSaCOp3d0YtR2kXD3nv9y5kE7LBFE+wWw==
   dependencies:
     "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.2.0"


### PR DESCRIPTION
## Change Summary

Add an auth actions to parse a sign in message from a protocol URI and an app action to verify sign in messages.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [ ] All commits have been signed
