### PR TITLE
feat: pass provider to SIWE

### DIFF
--- a/packages/connect/src/actions/app/verifySignInMessage.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.ts
@@ -15,6 +15,7 @@ export const verifySignInMessage = async (
 ): VerifySignInMessageResponse => {
   const result = await verify(message, signature, {
     getFid: client.ethereum.getFid,
+    provider: client.ethereum.provider,
   });
   if (result.isErr()) {
     throw result.error;

--- a/packages/connect/src/clients/ethereum/viem.ts
+++ b/packages/connect/src/clients/ethereum/viem.ts
@@ -1,9 +1,11 @@
 import { Hex, createPublicClient, http } from "viem";
 import { optimism } from "viem/chains";
+import { JsonRpcProvider } from "ethers";
 import { ID_REGISTRY_ADDRESS, idRegistryABI } from "@farcaster/hub-web";
 
 export interface Ethereum {
   getFid: (custody: Hex) => Promise<BigInt>;
+  provider: JsonRpcProvider;
 }
 
 interface ViemConfigArgs {
@@ -25,7 +27,17 @@ export const viem = (args?: ViemConfigArgs): Ethereum => {
     });
   };
 
+  const getProvider = () => {
+    const { chain, transport } = publicClient;
+    const network = {
+      chainId: chain.id,
+      name: chain.name,
+    };
+    return new JsonRpcProvider(transport.url, network);
+  };
+
   return {
     getFid,
+    provider: getProvider(),
   };
 };

--- a/test/client/src/e2e.test.ts
+++ b/test/client/src/e2e.test.ts
@@ -56,7 +56,7 @@ describe("clients", () => {
         response: pendingStatusResponse,
         data: { state: pendingState },
       } = await appClient.status({ channelToken });
-      expect(pendingStatusResponse.status).toBe(200);
+      expect(pendingStatusResponse.status).toBe(202);
       expect(pendingState).toBe("pending");
 
       // 3. Auth client generates a sign in message
@@ -101,7 +101,7 @@ describe("clients", () => {
         signature: sig,
         ...userData,
       });
-      expect(authResponse.status).toBe(200);
+      expect(authResponse.status).toBe(201);
 
       // 4. App client polls channel status
       const {


### PR DESCRIPTION
## Change Summary

SIWE uses Ethers to verify smart contract signatures. Add a `getProvider` function to `client.ethereum` that converts a Viem public client to an Ethers provider. Pass this to SIWE, so we use the configured RPC for contract signature verification.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
