### PR TITLE
fix: fall back to default RPC

### DIFF
--- a/packages/connect/src/actions/app/verifySignInMessage.test.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.test.ts
@@ -45,4 +45,27 @@ describe("verifySignInMessage", () => {
       }),
     ).rejects.toStrictEqual(error);
   });
+
+  test("verifies 1271 sign in message", async () => {
+    const LGTM = "0xC89858205c6AdDAD842E1F58eD6c42452671885A";
+    const message = authClient.buildSignInMessage({
+      ...siweParams,
+      address: LGTM,
+      fid: 1234,
+    });
+
+    const signature = await account.signMessage({
+      message: message.toMessage(),
+    });
+
+    const errMsg = `Invalid resource: signer ${LGTM} does not own fid 1234.`;
+    const error = new ConnectError("unauthorized", errMsg);
+
+    await expect(
+      client.verifySignInMessage({
+        message,
+        signature,
+      }),
+    ).rejects.toStrictEqual(error);
+  });
 });

--- a/packages/connect/src/clients/ethereum/viem.ts
+++ b/packages/connect/src/clients/ethereum/viem.ts
@@ -33,7 +33,8 @@ export const viem = (args?: ViemConfigArgs): Ethereum => {
       chainId: chain.id,
       name: chain.name,
     };
-    return new JsonRpcProvider(transport.url, network);
+    const rpc = transport.url ?? chain.rpcUrls.default.http[0];
+    return new JsonRpcProvider(rpc, network);
   };
 
   return {


### PR DESCRIPTION
## Change Summary

`transport.url` is only set if the client is created with an explicit RPC URL. If it's not present, fall back to the network default.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
