### PR TITLE
fix: set react module private

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "connect-react",
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "main": "./dist/connect-react.umd.cjs",
   "module": "./dist/connect-react.js",


### PR DESCRIPTION
## Change Summary

The React hooks/component package should be private for now.
