### PR TITLE
feat: return error objects

### DIFF
--- a/.changeset/hungry-llamas-remember.md
+++ b/.changeset/hungry-llamas-remember.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/connect": patch
+---
+
+Return error responses

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -41,6 +41,8 @@ const channel = await appClient.connect({
     channelToken: string;
     connectURI: string;
   }
+  isError: boolean;
+  error: Error;
 }
 ```
 
@@ -124,6 +126,8 @@ const status = await appClient.status({
         displayName?: string
         pfpUrl?: string
     }
+    isError: boolean
+    error: Error
 }
 ```
 
@@ -171,6 +175,8 @@ const status = await appClient.watchStatus({
         displayName?: string
         pfpUrl?: string
     }
+    isError: boolean
+    error: Error
 }
 ```
 
@@ -186,7 +192,7 @@ Example: `"210f1718-427e-46a4-99e3-2207f21f83ec"`
 
 ###### timeout
 
-Polling timeout, in milliseconds. If the connect request is not completed before the timeout, `watchStatus` throws.
+Polling timeout, in milliseconds. If the connect request is not completed before the timeout, `watchStatus` returns an error.
 
 Type: `number`
 
@@ -235,6 +241,8 @@ const { data, success, fid } = await appClient.verifySignInMessage({
     data: SiweMessage,
     success: boolean,
     fid: number
+    isError: boolean
+    error: Error
 }
 ```
 
@@ -279,7 +287,7 @@ Parse the Sign In With Farcaster URI provided by a connected app user.
 
 Returns the parsed parameters. Your app should use these to construct a Sign In With Farcaster message.
 
-Throws if URI is invalid.
+Returns an error if URI is invalid.
 
 ```ts
 const params = authClient.parseSignInURI({
@@ -300,6 +308,8 @@ const params = authClient.parseSignInURI({
     expirationTime?: string
     requestId?: string
   }
+  isError: boolean
+  error: Error
 }
 ```
 
@@ -337,6 +347,8 @@ const { siweMessage, message } = authClient.buildSignInMessage({
 {
   siweMessage: SiweMessage;
   message: string;
+  isError: boolean;
+  error: Error;
 }
 ```
 
@@ -438,6 +450,8 @@ const params = authClient.authenticate({
       displayName?: string
       pfpUrl?: string
   }
+  isError: boolean
+  error: Error
 }
 ```
 

--- a/packages/connect/src/actions/app/connect.test.ts
+++ b/packages/connect/src/actions/app/connect.test.ts
@@ -1,6 +1,7 @@
 import { createAppClient } from "../../clients/createAppClient";
 import { jest } from "@jest/globals";
 import { viem } from "../../clients/ethereum/viem";
+import { ConnectError } from "../../errors";
 
 describe("connect", () => {
   const client = createAppClient({
@@ -44,5 +45,19 @@ describe("connect", () => {
         "Content-Type": "application/json",
       },
     });
+  });
+
+  test("handles errors", async () => {
+    const spy = jest.spyOn(global, "fetch").mockRejectedValue(new Error("some error"));
+
+    const res = await client.connect({
+      siweUri,
+      domain,
+      nonce,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(res.isError).toBe(true);
+    expect(res.error).toEqual(new ConnectError("unknown", "some error"));
   });
 });

--- a/packages/connect/src/actions/app/connect.ts
+++ b/packages/connect/src/actions/app/connect.ts
@@ -1,8 +1,9 @@
+import { AsyncUnwrapped, unwrap } from "../../errors";
 import { Client } from "../../clients/createClient";
-import { AsyncHttpResponse, post } from "../../clients/transports/http";
+import { HttpResponse, post } from "../../clients/transports/http";
 
 export type ConnectArgs = ConnectRequest;
-export type ConnectResponse = AsyncHttpResponse<ConnectAPIResponse>;
+export type ConnectResponse = AsyncUnwrapped<HttpResponse<ConnectAPIResponse>>;
 
 interface ConnectRequest {
   siweUri: string;
@@ -21,5 +22,6 @@ interface ConnectAPIResponse {
 const path = "connect";
 
 export const connect = async (client: Client, { ...request }: ConnectArgs): ConnectResponse => {
-  return post<ConnectRequest, ConnectAPIResponse>(client, path, request);
+  const response = await post<ConnectRequest, ConnectAPIResponse>(client, path, request);
+  return unwrap(response);
 };

--- a/packages/connect/src/actions/app/status.ts
+++ b/packages/connect/src/actions/app/status.ts
@@ -1,11 +1,12 @@
+import { AsyncUnwrapped, unwrap } from "../../errors";
 import { Client } from "../../clients/createClient";
-import { get, AsyncHttpResponse } from "../../clients/transports/http";
+import { get, HttpResponse } from "../../clients/transports/http";
 
 export interface StatusArgs {
   channelToken: string;
 }
 
-export type StatusResponse = AsyncHttpResponse<StatusAPIResponse>;
+export type StatusResponse = AsyncUnwrapped<HttpResponse<StatusAPIResponse>>;
 
 interface StatusAPIResponse {
   state: "pending" | "completed";
@@ -22,5 +23,8 @@ interface StatusAPIResponse {
 const path = "connect/status";
 
 export const status = async (client: Client, { channelToken }: StatusArgs): StatusResponse => {
-  return get<StatusAPIResponse>(client, path, { authToken: channelToken });
+  const response = await get<StatusAPIResponse>(client, path, {
+    authToken: channelToken,
+  });
+  return unwrap(response);
 };

--- a/packages/connect/src/actions/app/verifySignInMessage.test.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.test.ts
@@ -36,14 +36,13 @@ describe("verifySignInMessage", () => {
     });
 
     const errMsg = `Invalid resource: signer ${account.address} does not own fid 1234.`;
-    const error = new ConnectError("unauthorized", errMsg);
-
-    await expect(
-      client.verifySignInMessage({
-        message,
-        signature,
-      }),
-    ).rejects.toStrictEqual(error);
+    const err = new ConnectError("unauthorized", errMsg);
+    const { isError, error } = await client.verifySignInMessage({
+      message,
+      signature,
+    });
+    expect(isError).toBe(true);
+    expect(error).toStrictEqual(err);
   });
 
   test("verifies 1271 sign in message", async () => {
@@ -59,13 +58,12 @@ describe("verifySignInMessage", () => {
     });
 
     const errMsg = `Invalid resource: signer ${LGTM} does not own fid 1234.`;
-    const error = new ConnectError("unauthorized", errMsg);
-
-    await expect(
-      client.verifySignInMessage({
-        message,
-        signature,
-      }),
-    ).rejects.toStrictEqual(error);
+    const err = new ConnectError("unauthorized", errMsg);
+    const { isError, error } = await client.verifySignInMessage({
+      message,
+      signature,
+    });
+    expect(isError).toBe(true);
+    expect(error).toStrictEqual(err);
   });
 });

--- a/packages/connect/src/actions/app/verifySignInMessage.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.ts
@@ -1,13 +1,14 @@
 import { SiweMessage } from "siwe";
 import { Client } from "../../clients/createClient";
-import { SignInResponse, verify } from "../../messages/verify";
+import { VerifyResponse, verify } from "../../messages/verify";
+import { Unwrapped, unwrap } from "../../errors";
 
 export interface VerifySignInMessageArgs {
   message: string | Partial<SiweMessage>;
   signature: `0x${string}`;
 }
 
-export type VerifySignInMessageResponse = Promise<SignInResponse>;
+export type VerifySignInMessageResponse = Promise<Unwrapped<VerifyResponse>>;
 
 export const verifySignInMessage = async (
   client: Client,
@@ -17,9 +18,5 @@ export const verifySignInMessage = async (
     getFid: client.ethereum.getFid,
     provider: client.ethereum.provider,
   });
-  if (result.isErr()) {
-    throw result.error;
-  } else {
-    return result.value;
-  }
+  return unwrap(result);
 };

--- a/packages/connect/src/actions/app/watchStatus.ts
+++ b/packages/connect/src/actions/app/watchStatus.ts
@@ -1,5 +1,6 @@
+import { AsyncUnwrapped, unwrap } from "../../errors";
 import { Client } from "../../clients/createClient";
-import { AsyncHttpResponse, poll, HttpResponse } from "../../clients/transports/http";
+import { poll, HttpResponse } from "../../clients/transports/http";
 
 export interface WatchStatusArgs {
   channelToken: string;
@@ -8,7 +9,7 @@ export interface WatchStatusArgs {
   onResponse?: (response: HttpResponse<StatusAPIResponse>) => void;
 }
 
-export type WatchStatusResponse = AsyncHttpResponse<StatusAPIResponse>;
+export type WatchStatusResponse = AsyncUnwrapped<HttpResponse<StatusAPIResponse>>;
 
 interface StatusAPIResponse {
   state: "pending" | "completed";
@@ -28,7 +29,7 @@ const path = "connect/status";
 const voidCallback = () => {};
 
 export const watchStatus = async (client: Client, args: WatchStatusArgs): WatchStatusResponse => {
-  return poll<StatusAPIResponse>(
+  const result = await poll<StatusAPIResponse>(
     client,
     path,
     {
@@ -38,4 +39,5 @@ export const watchStatus = async (client: Client, args: WatchStatusArgs): WatchS
     },
     { authToken: args.channelToken },
   );
+  return unwrap(result);
 };

--- a/packages/connect/src/actions/auth/authenticate.ts
+++ b/packages/connect/src/actions/auth/authenticate.ts
@@ -1,12 +1,13 @@
 import { StatusResponse } from "../app/status";
-import { post, AsyncHttpResponse } from "../../clients/transports/http";
+import { post, HttpResponse } from "../../clients/transports/http";
 import { Client } from "../../clients/createClient";
+import { AsyncUnwrapped, unwrap } from "../../errors";
 
 export interface AuthenticateArgs extends AuthenticateRequest {
   channelToken: string;
 }
 
-export type AuthenticateResponse = AsyncHttpResponse<AuthenticateAPIResponse>;
+export type AuthenticateResponse = AsyncUnwrapped<HttpResponse<AuthenticateAPIResponse>>;
 
 interface AuthenticateRequest {
   message: string;
@@ -26,5 +27,8 @@ export const authenticate = async (
   client: Client,
   { channelToken, ...request }: AuthenticateArgs,
 ): AuthenticateResponse => {
-  return post<AuthenticateRequest, AuthenticateAPIResponse>(client, path, request, { authToken: channelToken });
+  const result = await post<AuthenticateRequest, AuthenticateAPIResponse>(client, path, request, {
+    authToken: channelToken,
+  });
+  return unwrap(result);
 };

--- a/packages/connect/src/actions/auth/buildSignInMessage.ts
+++ b/packages/connect/src/actions/auth/buildSignInMessage.ts
@@ -1,19 +1,10 @@
 import { Client } from "clients/createClient";
-import { build, SignInMessageParams } from "../../messages/build";
-import { SiweMessage } from "siwe";
+import { build, BuildResponse, SignInMessageParams } from "../../messages/build";
+import { Unwrapped, unwrap } from "../../errors";
 
 export type BuildSignInMessageArgs = SignInMessageParams;
-export interface BuildSignInMessageResponse {
-  siweMessage: SiweMessage;
-  message: string;
-}
+export type BuildSignInMessageResponse = Unwrapped<BuildResponse>;
 
 export const buildSignInMessage = (_client: Client, args: BuildSignInMessageArgs): BuildSignInMessageResponse => {
-  const result = build(args);
-  if (result.isErr()) {
-    throw result.error;
-  } else {
-    const siweMessage = result.value;
-    return { siweMessage, message: siweMessage.toMessage() };
-  }
+  return unwrap(build(args));
 };

--- a/packages/connect/src/actions/auth/parseSignInURI.ts
+++ b/packages/connect/src/actions/auth/parseSignInURI.ts
@@ -1,16 +1,12 @@
+import { Unwrapped, unwrap } from "../../errors";
 import { Client } from "../../clients/createClient";
 import { parseSignInURI as parse, ParsedSignInURI } from "../../messages/parseSignInURI";
 
 export interface ParseSignInURIArgs {
   uri: string;
 }
-export type ParseSignInURIResponse = ParsedSignInURI;
+export type ParseSignInURIResponse = Unwrapped<ParsedSignInURI>;
 
 export const parseSignInURI = (_client: Client, { uri }: ParseSignInURIArgs): ParseSignInURIResponse => {
-  const result = parse(uri);
-  if (result.isErr()) {
-    throw result.error;
-  } else {
-    return result.value;
-  }
+  return unwrap(parse(uri));
 };

--- a/packages/connect/src/errors.ts
+++ b/packages/connect/src/errors.ts
@@ -65,3 +65,24 @@ export type ConnectErrorCode =
 /** Type alias for shorthand when handling errors */
 export type ConnectResult<T> = Result<T, ConnectError>;
 export type ConnectAsyncResult<T> = Promise<ConnectResult<T>>;
+export type NoneOf<T> = {
+  [K in keyof T]: never;
+};
+export type Unwrapped<T> =
+  | (T & {
+      isError: false;
+      error?: never;
+    })
+  | (NoneOf<T> & {
+      isError: true;
+      error?: ConnectError;
+    });
+export type AsyncUnwrapped<T> = Promise<Unwrapped<T>>;
+
+export const unwrap = <T>(result: ConnectResult<T>): Unwrapped<T> => {
+  if (result.isErr()) {
+    return { error: result.error, isError: true };
+  } else {
+    return { ...result.value, isError: false };
+  }
+};

--- a/packages/connect/src/messages/build.test.ts
+++ b/packages/connect/src/messages/build.test.ts
@@ -16,12 +16,14 @@ describe("build", () => {
       fid: 5678,
     });
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toMatchObject({
+    const { siweMessage, message } = result._unsafeUnwrap();
+    expect(siweMessage).toMatchObject({
       ...siweParams,
       statement: "Farcaster Connect",
       chainId: 10,
       resources: ["farcaster://fid/5678"],
     });
+    expect(message).toEqual(siweMessage.toMessage());
   });
 
   test("handles additional resources", () => {
@@ -31,7 +33,8 @@ describe("build", () => {
       resources: ["https://example.com/resource"],
     });
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toMatchObject({
+    const { siweMessage } = result._unsafeUnwrap();
+    expect(siweMessage).toMatchObject({
       ...siweParams,
       statement: "Farcaster Connect",
       chainId: 10,

--- a/packages/connect/src/messages/build.ts
+++ b/packages/connect/src/messages/build.ts
@@ -1,4 +1,5 @@
 import { SiweMessage } from "siwe";
+import { err, ok } from "neverthrow";
 import { ConnectResult } from "../errors";
 import { validate } from "./validate";
 import { parseSignInURI } from "./parseSignInURI";
@@ -8,18 +9,27 @@ export type FarcasterResourceParams = {
   fid: number;
 };
 export type SignInMessageParams = Partial<SiweMessage> & FarcasterResourceParams;
+export interface BuildResponse {
+  siweMessage: SiweMessage;
+  message: string;
+}
 
-export const build = (params: SignInMessageParams): ConnectResult<SiweMessage> => {
+export const build = (params: SignInMessageParams): ConnectResult<BuildResponse> => {
   const { fid, ...siweParams } = params;
   const resources = siweParams.resources ?? [];
   siweParams.version = "1";
   siweParams.statement = STATEMENT;
   siweParams.chainId = CHAIN_ID;
   siweParams.resources = [buildFidResource(fid), ...resources];
-  return validate(siweParams);
+  const valid = validate(siweParams);
+  if (valid.isErr()) return err(valid.error);
+  else {
+    const siweMessage = valid.value;
+    return ok({ siweMessage, message: siweMessage.toMessage() });
+  }
 };
 
-export const buildFromSignInURI = (signInUri: string, fid: number): ConnectResult<SiweMessage> => {
+export const buildFromSignInURI = (signInUri: string, fid: number): ConnectResult<BuildResponse> => {
   return parseSignInURI(signInUri).andThen(({ params }) => build({ ...params, fid }));
 };
 

--- a/packages/connect/src/messages/verify.test.ts
+++ b/packages/connect/src/messages/verify.test.ts
@@ -24,12 +24,12 @@ describe("verify", () => {
       address: account.address,
       fid: 1234,
     });
-    const message = res._unsafeUnwrap();
-    const sig = await account.signMessage({ message: message.toMessage() });
+    const { siweMessage, message } = res._unsafeUnwrap();
+    const sig = await account.signMessage({ message });
     const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toStrictEqual({
-      data: message,
+    expect(result._unsafeUnwrap()).toEqual({
+      data: siweMessage,
       success: true,
       fid: 1234,
     });
@@ -43,12 +43,12 @@ describe("verify", () => {
       address: account.address,
       fid: 1234,
     });
-    const message = res._unsafeUnwrap();
-    const sig = await account.signMessage({ message: message.toMessage() });
+    const { siweMessage, message } = res._unsafeUnwrap();
+    const sig = await account.signMessage({ message });
     const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toStrictEqual({
-      data: message,
+    expect(result._unsafeUnwrap()).toEqual({
+      data: siweMessage,
       success: true,
       fid: 1234,
     });
@@ -63,12 +63,12 @@ describe("verify", () => {
       address: "0xC89858205c6AdDAD842E1F58eD6c42452671885A",
       fid: 1234,
     });
-    const message = res._unsafeUnwrap();
-    const sig = await account.signMessage({ message: message.toMessage() });
+    const { siweMessage, message } = res._unsafeUnwrap();
+    const sig = await account.signMessage({ message });
     const result = await verify(message, sig, { getFid, provider });
     expect(result.isOk()).toBe(true);
-    expect(result._unsafeUnwrap()).toStrictEqual({
-      data: message,
+    expect(result._unsafeUnwrap()).toEqual({
+      data: siweMessage,
       success: true,
       fid: 1234,
     });
@@ -82,8 +82,8 @@ describe("verify", () => {
       address: "0xC89858205c6AdDAD842E1F58eD6c42452671885A",
       fid: 1234,
     });
-    const message = res._unsafeUnwrap();
-    const sig = await account.signMessage({ message: message.toMessage() });
+    const { message } = res._unsafeUnwrap();
+    const sig = await account.signMessage({ message });
     const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(false);
     const err = result._unsafeUnwrapErr();
@@ -94,15 +94,16 @@ describe("verify", () => {
   test("invalid SIWE message", async () => {
     const getFid = (_custody: Hex) => Promise.resolve(1234n);
 
-    const message = build({
+    const res = build({
       ...siweParams,
       address: zeroAddress,
       fid: 1234,
     });
+    const { message } = res._unsafeUnwrap();
     const sig = await account.signMessage({
-      message: message._unsafeUnwrap().toMessage(),
+      message,
     });
-    const result = await verify(message._unsafeUnwrap(), sig, { getFid });
+    const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(false);
     const err = result._unsafeUnwrapErr();
     expect(err.errCode).toBe("unauthorized");
@@ -112,15 +113,16 @@ describe("verify", () => {
   test("invalid fid owner", async () => {
     const getFid = (_custody: Hex) => Promise.resolve(5678n);
 
-    const message = build({
+    const res = build({
       ...siweParams,
       address: account.address,
       fid: 1234,
     });
+    const { message } = res._unsafeUnwrap();
     const sig = await account.signMessage({
-      message: message._unsafeUnwrap().toMessage(),
+      message,
     });
-    const result = await verify(message._unsafeUnwrap(), sig, { getFid });
+    const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(false);
     const err = result._unsafeUnwrapErr();
     expect(err.errCode).toBe("unauthorized");
@@ -130,15 +132,16 @@ describe("verify", () => {
   test("client error", async () => {
     const getFid = (_custody: Hex) => Promise.reject(new Error("client error"));
 
-    const message = build({
+    const res = build({
       ...siweParams,
       address: account.address,
       fid: 1234,
     });
+    const { message } = res._unsafeUnwrap();
     const sig = await account.signMessage({
-      message: message._unsafeUnwrap().toMessage(),
+      message,
     });
-    const result = await verify(message._unsafeUnwrap(), sig, { getFid });
+    const result = await verify(message, sig, { getFid });
     expect(result.isOk()).toBe(false);
     const err = result._unsafeUnwrapErr();
     expect(err.errCode).toBe("unavailable");
@@ -146,15 +149,16 @@ describe("verify", () => {
   });
 
   test("missing verifier", async () => {
-    const message = build({
+    const res = build({
       ...siweParams,
       address: account.address,
       fid: 1234,
     });
+    const { message } = res._unsafeUnwrap();
     const sig = await account.signMessage({
-      message: message._unsafeUnwrap().toMessage(),
+      message,
     });
-    const result = await verify(message._unsafeUnwrap(), sig);
+    const result = await verify(message, sig);
     expect(result.isOk()).toBe(false);
     const err = result._unsafeUnwrapErr();
     expect(err.errCode).toBe("unavailable");


### PR DESCRIPTION
## Change Summary

Use `neverthrow` for error handling internally. Catch and unwrap errors at the top level and return them as data.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
