### PR TITLE
refactor: split up hooks

### DIFF
--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -190,7 +190,7 @@ Type: `string`
 
 Example: `"210f1718-427e-46a4-99e3-2207f21f83ec"`
 
-###### timeout
+###### timeout (optional)
 
 Polling timeout, in milliseconds. If the connect request is not completed before the timeout, `watchStatus` returns an error.
 
@@ -198,7 +198,7 @@ Type: `number`
 
 Example: `60_000`
 
-###### interval
+###### interval (optional)
 
 Polling interval, in milliseconds. The client will check for updates at this frequency.
 
@@ -206,7 +206,7 @@ Type: `number`
 
 Example: `1_000`
 
-###### onResponse
+###### onResponse (optional)
 
 Callback function invoked each time the client polls for an update and receives a response from the relay server. Receives the return value of the latest `status` request.
 

--- a/packages/connect/src/actions/app/connect.test.ts
+++ b/packages/connect/src/actions/app/connect.test.ts
@@ -5,7 +5,6 @@ import { ConnectError } from "../../errors";
 
 describe("connect", () => {
   const client = createAppClient({
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   });
 

--- a/packages/connect/src/actions/app/status.test.ts
+++ b/packages/connect/src/actions/app/status.test.ts
@@ -4,7 +4,6 @@ import { viem } from "../../clients/ethereum/viem";
 
 describe("status", () => {
   const client = createAppClient({
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   });
 

--- a/packages/connect/src/actions/app/verifySignInMessage.test.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.test.ts
@@ -6,12 +6,10 @@ import { ConnectError } from "../../errors";
 
 describe("verifySignInMessage", () => {
   const client = createAppClient({
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   });
 
   const authClient = createAuthClient({
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   });
 

--- a/packages/connect/src/actions/app/watchStatus.test.ts
+++ b/packages/connect/src/actions/app/watchStatus.test.ts
@@ -4,7 +4,6 @@ import { viem } from "../../clients/ethereum/viem";
 
 describe("status", () => {
   const client = createAppClient({
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   });
 
@@ -12,7 +11,7 @@ describe("status", () => {
     jest.restoreAllMocks();
   });
 
-  test("", async () => {
+  test("polls for status changes", async () => {
     const pending1 = new Response(JSON.stringify({ state: "pending" }), {
       status: 202,
     });

--- a/packages/connect/src/actions/app/watchStatus.ts
+++ b/packages/connect/src/actions/app/watchStatus.ts
@@ -33,7 +33,7 @@ export const watchStatus = async (client: Client, args: WatchStatusArgs): WatchS
     client,
     path,
     {
-      timeout: args?.timeout ?? 10000,
+      timeout: args?.timeout ?? 300_000,
       interval: args?.interval ?? 1000,
       onResponse: args?.onResponse ?? voidCallback,
     },

--- a/packages/connect/src/clients/createAppClient.test.ts
+++ b/packages/connect/src/clients/createAppClient.test.ts
@@ -3,7 +3,6 @@ import { viem } from "./ethereum/viem";
 
 describe("createAppClient", () => {
   const config = {
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   };
 

--- a/packages/connect/src/clients/createAuthClient.test.ts
+++ b/packages/connect/src/clients/createAuthClient.test.ts
@@ -3,7 +3,6 @@ import { viem } from "./ethereum/viem";
 
 describe("createAuthClient", () => {
   const config = {
-    relayURI: "https://connect.farcaster.xyz",
     ethereum: viem(),
   };
 

--- a/packages/connect/src/clients/createClient.test.ts
+++ b/packages/connect/src/clients/createClient.test.ts
@@ -4,7 +4,6 @@ import { viem } from "./ethereum/viem";
 describe("createClient", () => {
   const ethereum = viem();
   const config = {
-    relayURI: "https://connect.farcaster.xyz",
     ethereum,
   };
 
@@ -14,7 +13,7 @@ describe("createClient", () => {
     client = createClient(config);
   });
 
-  test("adds version to config", () => {
+  test("adds defaults to config", () => {
     expect(client.config).toEqual({
       relayURI: "https://connect.farcaster.xyz",
       version: "v1",
@@ -30,6 +29,18 @@ describe("createClient", () => {
     expect(client.config).toEqual({
       relayURI: "https://connect.farcaster.xyz",
       version: "v2",
+    });
+  });
+
+  test("overrides relayURI", () => {
+    client = createClient({
+      ...config,
+      relayURI: "https://custom-server.example.com",
+    });
+
+    expect(client.config).toEqual({
+      relayURI: "https://custom-server.example.com",
+      version: "v1",
     });
   });
 

--- a/packages/connect/src/clients/createClient.ts
+++ b/packages/connect/src/clients/createClient.ts
@@ -1,7 +1,7 @@
 import { Ethereum } from "../clients/ethereum/viem";
 
 export interface CreateClientArgs {
-  relayURI: string;
+  relayURI?: string;
   version?: string;
   ethereum: Ethereum;
 }
@@ -17,6 +17,7 @@ export interface Client {
 }
 
 const configDefaults = {
+  relayURI: "https://connect.farcaster.xyz",
   version: "v1",
 };
 

--- a/packages/react/src/hooks/useAppClient.ts
+++ b/packages/react/src/hooks/useAppClient.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { AppClient, createAppClient, viem } from "@farcaster/connect";
+import { JsonRpcProvider } from "ethers";
+
+interface UseAppClientArgs {
+  relayURI?: string;
+}
+
+const defaults = {
+  relayURI: "http://localhost:8000",
+};
+
+function useAppClient(args: UseAppClientArgs) {
+  const { relayURI } = {
+    ...args,
+    ...defaults,
+  };
+
+  const [appClient, setAppClient] = useState<AppClient>();
+
+  useEffect(() => {
+    const client = createAppClient({
+      relayURI,
+      ethereum: viem(),
+    });
+    client.ethereum.provider = new JsonRpcProvider(
+      "https://mainnet.optimism.io"
+    );
+    setAppClient(client);
+  }, [relayURI]);
+
+  return {
+    appClient,
+  };
+}
+
+export default useAppClient;

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppClient, ConnectError } from "@farcaster/connect";
+import QRCode from "qrcode";
+
+interface UseConnectArgs {
+  siweUri: string;
+  domain: string;
+  appClient?: AppClient;
+}
+
+function useConnect(args: UseConnectArgs) {
+  const { appClient, siweUri, domain } = args;
+
+  const [qrCodeURI, setQrCodeURI] = useState<string>();
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [channelToken, setChannelToken] = useState<string>();
+  const [connectURI, setConnectURI] = useState<string>();
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<ConnectError>();
+
+  const connect = useCallback(async () => {
+    if (appClient && !channelToken) {
+      const {
+        data: { channelToken, connectURI },
+        isError: isConnectError,
+        error: connectError,
+      } = await appClient.connect({
+        siweUri,
+        domain,
+      });
+      if (isConnectError) {
+        setIsError(true);
+        setError(connectError);
+      } else {
+        setChannelToken(channelToken);
+        setConnectURI(connectURI);
+        setIsSuccess(true);
+      }
+    }
+  }, [appClient, domain, siweUri, channelToken]);
+
+  const generateQRCode = useCallback(async () => {
+    if (connectURI) {
+      const qrCode = await QRCode.toDataURL(connectURI);
+      setQrCodeURI(qrCode);
+    }
+  }, [connectURI]);
+
+  useEffect(() => {
+    if (connectURI) {
+      generateQRCode();
+    }
+  }, [connectURI, generateQRCode]);
+
+  useEffect(() => {
+    if (enabled) {
+      connect();
+    }
+  }, [enabled, connect]);
+
+  return {
+    connect: () => setEnabled(true),
+    isSuccess,
+    isError,
+    error,
+    data: { channelToken, connectURI, qrCodeURI },
+  };
+}
+
+export default useConnect;

--- a/packages/react/src/hooks/useVerifySignInMessage.ts
+++ b/packages/react/src/hooks/useVerifySignInMessage.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppClient, ConnectError } from "@farcaster/connect";
+
+interface UseVerifySignInMessageArgs {
+  appClient?: AppClient;
+  message?: string;
+  signature?: `0x${string}`;
+}
+
+function useVerifySignInMessage(args: UseVerifySignInMessageArgs) {
+  const { appClient, message, signature } = args;
+
+  const [validSignature, setValidSignature] = useState<boolean>(false);
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<ConnectError>();
+
+  const verifySignInMessage = useCallback(async () => {
+    if (appClient && message && signature) {
+      const {
+        success,
+        isError: isVerifyError,
+        error: verifyError,
+      } = await appClient.verifySignInMessage({
+        message,
+        signature,
+      });
+      if (isVerifyError) {
+        setIsError(true);
+        setError(verifyError);
+      } else {
+        setValidSignature(success);
+        setIsSuccess(true);
+      }
+    }
+  }, [appClient, message, signature]);
+
+  useEffect(() => {
+    if (message && signature) {
+      verifySignInMessage();
+    }
+  }, [message, signature, verifySignInMessage]);
+
+  return {
+    isSuccess,
+    isError,
+    error,
+    data: { validSignature },
+  };
+}
+
+export default useVerifySignInMessage;

--- a/packages/react/src/hooks/useWatchStatus.ts
+++ b/packages/react/src/hooks/useWatchStatus.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppClient, ConnectError } from "@farcaster/connect";
+
+interface UseWatchStatusArgs {
+  appClient?: AppClient;
+  channelToken?: string;
+  timeout?: number;
+  interval?: number;
+}
+
+interface StatusAPIResponse {
+  state: "" | "pending" | "completed";
+  nonce: string;
+  connectURI: string;
+  message?: string;
+  signature?: `0x${string}`;
+  fid?: number;
+  username?: string;
+  bio?: string;
+  displayName?: string;
+  pfpUrl?: string;
+}
+
+const defaults = {
+  timeout: 300_000,
+  interval: 1_500,
+};
+
+function useWatchStatus(args: UseWatchStatusArgs) {
+  const { appClient, channelToken, timeout, interval } = {
+    ...args,
+    ...defaults,
+  };
+
+  const [statusData, setStatusData] = useState<StatusAPIResponse>();
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<ConnectError>();
+
+  const watchStatus = useCallback(async () => {
+    if (appClient && channelToken) {
+      setIsPolling(true);
+      const {
+        data,
+        isError: isWatchStatusError,
+        error: watchStatusError,
+      } = await appClient.watchStatus({
+        channelToken,
+        timeout,
+        interval,
+        onResponse: ({ data }) => {
+          setStatusData(data);
+        },
+      });
+      if (isWatchStatusError) {
+        setIsError(true);
+        setIsPolling(false);
+        setError(watchStatusError);
+      } else {
+        setIsSuccess(true);
+        setIsPolling(false);
+        setStatusData(data);
+      }
+    }
+  }, [appClient, channelToken, timeout, interval]);
+
+  useEffect(() => {
+    if (channelToken) {
+      watchStatus();
+    }
+  }, [channelToken, watchStatus]);
+
+  return {
+    isSuccess,
+    isPolling,
+    isError,
+    error,
+    data: statusData,
+  };
+}
+
+export default useWatchStatus;


### PR DESCRIPTION
## Motivation

Extract `useAppClient`, `useConnect`,  `useWatchStatus` and `useVerifySignInMessage` from `useSignIn` hook.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed