### PR TITLE
feat: add Warpcast auth key

### DIFF
--- a/apps/relay/.env.test
+++ b/apps/relay/.env.test
@@ -1,0 +1,1 @@
+AUTH_KEY="some-shared-secret"

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -8,8 +8,8 @@
     "build": "tsc --project ./tsconfig.json",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/",
-    "test": "yarn build && jest",
-    "test:ci": "yarn build && ENVIRONMENT=test NODE_OPTIONS=\"--max-old-space-size=4096\" jest --ci --forceExit --coverage",
+    "test": "yarn build && DOTENV_CONFIG_PATH=.env.test jest",
+    "test:ci": "yarn build && ENVIRONMENT=test NODE_OPTIONS=\"--max-old-space-size=4096\" DOTENV_CONFIG_PATH=.env.test jest --ci --forceExit --coverage",
     "start": "yarn build && node build/app.js start"
   },
   "engines": {

--- a/apps/relay/src/env.ts
+++ b/apps/relay/src/env.ts
@@ -6,3 +6,5 @@ export const REDIS_URL = process.env["REDIS_URL"] || "redis://localhost:6379";
 
 export const RELAY_SERVER_PORT = Number(process.env["RELAY_SERVER_PORT"] || "8000");
 export const RELAY_SERVER_HOST = process.env["RELAY_SERVER_HOST"] || "localhost";
+
+export const AUTH_KEY = process.env["AUTH_KEY"];

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -1,4 +1,5 @@
 import { FastifyError, FastifyReply, FastifyRequest } from "fastify";
+import { AUTH_KEY } from "./env";
 import { Logger } from "logger";
 import { generateNonce } from "siwe";
 
@@ -63,6 +64,9 @@ export async function connect(request: FastifyRequest<{ Body: ConnectRequest }>,
 }
 
 export async function authenticate(request: FastifyRequest<{ Body: AuthenticateRequest }>, reply: FastifyReply) {
+  const authKey = request.headers["x-farcaster-connect-auth-key"];
+  if (authKey !== AUTH_KEY) reply.code(401).send({ error: "Unauthorized" });
+
   const channelToken = request.channelToken;
   const { message, signature, fid, username, displayName, bio, pfpUrl } = request.body;
 

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -203,14 +203,30 @@ describe("relay server", () => {
 
     test("POST with valid token", async () => {
       const response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
-        headers: { Authorization: `Bearer ${channelToken}` },
+        headers: {
+          Authorization: `Bearer ${channelToken}`,
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
       });
       expect(response.status).toBe(201);
     });
 
     test("POST with invalid token", async () => {
       const response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
-        headers: { Authorization: "Bearer abc-123-def" },
+        headers: {
+          Authorization: "Bearer abc-123-def",
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
+      });
+      expect(response.status).toBe(401);
+    });
+
+    test("POST with invalid key", async () => {
+      const response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
+        headers: {
+          Authorization: "Bearer abc-123-def",
+          "X-Farcaster-Connect-Auth-Key": "invalid-shared-secret",
+        },
       });
       expect(response.status).toBe(401);
     });
@@ -271,7 +287,10 @@ describe("relay server", () => {
         throw new Error("read error");
       });
       const response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
-        headers: { Authorization: `Bearer ${channelToken}` },
+        headers: {
+          Authorization: `Bearer ${channelToken}`,
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
       });
       expect(response.status).toBe(500);
       expect(response.data).toStrictEqual({ error: "read error" });
@@ -282,7 +301,10 @@ describe("relay server", () => {
         throw new Error("update error");
       });
       const response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
-        headers: { Authorization: `Bearer ${channelToken}` },
+        headers: {
+          Authorization: `Bearer ${channelToken}`,
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
       });
       expect(response.status).toBe(500);
       expect(response.data).toStrictEqual({ error: "update error" });
@@ -373,7 +395,12 @@ describe("relay server", () => {
       expect(response.status).toBe(202);
       expect(response.data.state).toBe("pending");
 
-      response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, authHeaders);
+      response = await http.post(getFullUrl("/v1/connect/authenticate"), authenticateParams, {
+        headers: {
+          Authorization: `Bearer ${channelToken}`,
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
+      });
       expect(response.status).toBe(201);
 
       response = await http.get(getFullUrl("/v1/connect/status"), authHeaders);


### PR DESCRIPTION
## Motivation

In v1, only Warpcast is authorized to authenticate users.

## Change Summary

Add a shared secret API key required to POST to `/authenticate` 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed