### PR TITLE
feat: optional userData parameters

### DIFF
--- a/apps/relay/src/schemas.ts
+++ b/apps/relay/src/schemas.ts
@@ -58,6 +58,6 @@ export const authenticateRequestSchema = {
       format: "uri",
     },
   },
-  required: ["message", "signature", "fid", "username", "bio", "displayName", "pfpUrl"],
+  required: ["message", "signature", "fid"],
   additionalProperties: false,
 };

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -243,6 +243,17 @@ describe("relay server", () => {
       });
     });
 
+    test("optional body param", async () => {
+      const { username, ...missingUsername } = authenticateParams;
+      const response = await http.post(getFullUrl("/v1/connect/authenticate"), missingUsername, {
+        headers: {
+          Authorization: `Bearer ${channelToken}`,
+          "X-Farcaster-Connect-Auth-Key": "some-shared-secret",
+        },
+      });
+      expect(response.status).toBe(201);
+    });
+
     test("invalid username", async () => {
       const response = await http.post(
         getFullUrl("/v1/connect/authenticate"),

--- a/packages/connect/.changeset/odd-laws-sneeze.md
+++ b/packages/connect/.changeset/odd-laws-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/connect": patch
+"@farcaster/connect-relay": patch
+---
+
+Optional userData parameters

--- a/packages/connect/src/actions/auth/authenticate.ts
+++ b/packages/connect/src/actions/auth/authenticate.ts
@@ -13,10 +13,10 @@ interface AuthenticateRequest {
   message: string;
   signature: `0x${string}`;
   fid: number;
-  username: string;
-  bio: string;
-  displayName: string;
-  pfpUrl: string;
+  username?: string;
+  bio?: string;
+  displayName?: string;
+  pfpUrl?: string;
 }
 
 type AuthenticateAPIResponse = StatusResponse;


### PR DESCRIPTION
## Motivation

We don't always have profile data for a user, so these parameters should be optional.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
