### PR TITLE
fix: roll up types, publish v0.0.6

### DIFF
--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # connect-kit
 
+## 0.0.6
+
+### Patch Changes
+
+- Fix: roll up types
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect-kit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "./dist/connect-kit.umd.cjs",
   "module": "./dist/connect-kit.js",

--- a/packages/connect-kit/vite.config.ts
+++ b/packages/connect-kit/vite.config.ts
@@ -7,7 +7,7 @@ import dts from "vite-plugin-dts";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), vanillaExtractPlugin(), nodePolyfills(), dts()],
+  plugins: [react(), vanillaExtractPlugin(), nodePolyfills(), dts({ rollupTypes: true })],
   build: {
     lib: {
       entry: resolve(__dirname, "src/index.ts"),


### PR DESCRIPTION
## Change Summary

Roll up types into a single `connect-kit.d.ts` file.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
