### PR TITLE
fix: remove @farcaster/core dependency

### DIFF
--- a/.changeset/spotty-chefs-tie.md
+++ b/.changeset/spotty-chefs-tie.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/connect": patch
+---
+
+Remove @farcaster/core dependency

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "@farcaster/core": "^0.13.4",
+    "neverthrow": "^6.1.0",
     "siwe": "^2.1.4"
   },
   "peerDependencies": {

--- a/packages/connect/src/clients/ethereum/viem.ts
+++ b/packages/connect/src/clients/ethereum/viem.ts
@@ -1,7 +1,7 @@
 import { Hex, createPublicClient, http } from "viem";
 import { optimism } from "viem/chains";
 import { JsonRpcProvider } from "ethers";
-import { ID_REGISTRY_ADDRESS, idRegistryABI } from "@farcaster/core";
+import { ID_REGISTRY_ADDRESS, idRegistryABI } from "../../contracts/idRegistry";
 
 export interface Ethereum {
   getFid: (custody: Hex) => Promise<BigInt>;

--- a/packages/connect/src/contracts/idRegistry.ts
+++ b/packages/connect/src/contracts/idRegistry.ts
@@ -1,0 +1,1256 @@
+export const idRegistryABI = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_migrator",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_initialOwner",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "AlreadyMigrated",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "GatewayFrozen",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "HasId",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "HasNoId",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "currentNonce",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidAccountNonce",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidShortString",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSignature",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyGuardian",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyMigrator",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PermissionRevoked",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SignatureExpired",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "str",
+        type: "string",
+      },
+    ],
+    name: "StringTooLong",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Unauthorized",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "guardian",
+        type: "address",
+      },
+    ],
+    name: "Add",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+    ],
+    name: "AdminReset",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    name: "ChangeRecoveryAddress",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: "EIP712DomainChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "idGateway",
+        type: "address",
+      },
+    ],
+    name: "FreezeIdGateway",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "migratedAt",
+        type: "uint256",
+      },
+    ],
+    name: "Migrated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferStarted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "Paused",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+    ],
+    name: "Recover",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    name: "Register",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "guardian",
+        type: "address",
+      },
+    ],
+    name: "Remove",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "oldCounter",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "newCounter",
+        type: "uint256",
+      },
+    ],
+    name: "SetIdCounter",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "oldIdGateway",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newIdGateway",
+        type: "address",
+      },
+    ],
+    name: "SetIdGateway",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "oldMigrator",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newMigrator",
+        type: "address",
+      },
+    ],
+    name: "SetMigrator",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+    ],
+    name: "Transfer",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "Unpaused",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "CHANGE_RECOVERY_ADDRESS_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "TRANSFER_AND_CHANGE_RECOVERY_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "TRANSFER_TYPEHASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "VERSION",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "acceptOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "guardian",
+        type: "address",
+      },
+    ],
+    name: "addGuardian",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint24",
+            name: "fid",
+            type: "uint24",
+          },
+          {
+            internalType: "address",
+            name: "custody",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "recovery",
+            type: "address",
+          },
+        ],
+        internalType: "struct IIdRegistry.BulkRegisterData[]",
+        name: "ids",
+        type: "tuple[]",
+      },
+    ],
+    name: "bulkRegisterIds",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint24",
+            name: "fid",
+            type: "uint24",
+          },
+          {
+            internalType: "address",
+            name: "custody",
+            type: "address",
+          },
+        ],
+        internalType: "struct IIdRegistry.BulkRegisterDefaultRecoveryData[]",
+        name: "ids",
+        type: "tuple[]",
+      },
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    name: "bulkRegisterIdsWithDefaultRecovery",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint24[]",
+        name: "ids",
+        type: "uint24[]",
+      },
+    ],
+    name: "bulkResetIds",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    name: "changeRecoveryAddress",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "deadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "sig",
+        type: "bytes",
+      },
+    ],
+    name: "changeRecoveryAddressFor",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+    ],
+    name: "custodyOf",
+    outputs: [
+      {
+        internalType: "address",
+        name: "custody",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "domainSeparatorV4",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "eip712Domain",
+    outputs: [
+      {
+        internalType: "bytes1",
+        name: "fields",
+        type: "bytes1",
+      },
+      {
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "version",
+        type: "string",
+      },
+      {
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "verifyingContract",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "salt",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256[]",
+        name: "extensions",
+        type: "uint256[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "freezeIdGateway",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "gatewayFrozen",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "gracePeriod",
+    outputs: [
+      {
+        internalType: "uint24",
+        name: "",
+        type: "uint24",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "guardian",
+        type: "address",
+      },
+    ],
+    name: "guardians",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "isGuardian",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "structHash",
+        type: "bytes32",
+      },
+    ],
+    name: "hashTypedDataV4",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "idCounter",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "idGateway",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+    ],
+    name: "idOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "isMigrated",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "migrate",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "migratedAt",
+    outputs: [
+      {
+        internalType: "uint40",
+        name: "",
+        type: "uint40",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "migrator",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "name",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+    ],
+    name: "nonces",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pause",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "paused",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pendingOwner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "deadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "sig",
+        type: "bytes",
+      },
+    ],
+    name: "recover",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "recoveryDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "recoverySig",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "toDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "toSig",
+        type: "bytes",
+      },
+    ],
+    name: "recoverFor",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+    ],
+    name: "recoveryOf",
+    outputs: [
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+    ],
+    name: "register",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "guardian",
+        type: "address",
+      },
+    ],
+    name: "removeGuardian",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_counter",
+        type: "uint256",
+      },
+    ],
+    name: "setIdCounter",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_idGateway",
+        type: "address",
+      },
+    ],
+    name: "setIdGateway",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_migrator",
+        type: "address",
+      },
+    ],
+    name: "setMigrator",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "deadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "sig",
+        type: "bytes",
+      },
+    ],
+    name: "transfer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "deadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "sig",
+        type: "bytes",
+      },
+    ],
+    name: "transferAndChangeRecovery",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recovery",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "fromDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "fromSig",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "toDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "toSig",
+        type: "bytes",
+      },
+    ],
+    name: "transferAndChangeRecoveryFor",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "fromDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "fromSig",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "toDeadline",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "toSig",
+        type: "bytes",
+      },
+    ],
+    name: "transferFor",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unpause",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "useNonce",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "custodyAddress",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "fid",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "digest",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "sig",
+        type: "bytes",
+      },
+    ],
+    name: "verifyFidSignature",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "isValid",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export const ID_REGISTRY_ADDRESS = "0x00000000Fc6c5F01Fc30151999387Bb99A9f489b" as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,18 +1043,6 @@
     ref-napi "^3.0.3"
     viem "^1.12.2"
 
-"@farcaster/core@^0.13.4":
-  version "0.13.4"
-  resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.13.4.tgz#18df168e024186f084f0cd7c5f29fd051964a7f5"
-  integrity sha512-cvQLzD+r4/1kI763jox0ZtU5BkmYQjOvvabcYVvJAfIJUsQfwpcVJOEliLuO94a2pyZSp7/CLQN0In0RUIVKlQ==
-  dependencies:
-    "@noble/curves" "^1.0.0"
-    "@noble/hashes" "^1.3.0"
-    ffi-napi "^4.0.3"
-    neverthrow "^6.0.0"
-    ref-napi "^3.0.3"
-    viem "^1.12.2"
-
 "@farcaster/hub-nodejs@^0.10.19":
   version "0.10.19"
   resolved "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.10.19.tgz#b60b74219272c27e261a5a5b097eb5ea07ec8556"


### PR DESCRIPTION
## Change Summary

Remove `@farcaster/core` dependency from `@farcaster/connect`. We're only using this to read the ID Registry ABI and address, but it pulls in a 4MB library and requires browser polyfills. We should invest some attention in our build tooling for `@farcaster/core` and `@farcaster/hub-web` to make sure they're suitable for browsers.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
