### PR TITLE
chore: publish connect@0.0.5, connect-kit@0.0.7

### DIFF
--- a/.changeset/spotty-chefs-tie.md
+++ b/.changeset/spotty-chefs-tie.md
@@ -1,5 +1,0 @@
----
-"@farcaster/connect": patch
----
-
-Remove @farcaster/core dependency

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # connect-kit
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [6e70ebc]
+  - @farcaster/connect@0.0.5
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect-kit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "main": "./dist/connect-kit.umd.cjs",
   "module": "./dist/connect-kit.js",
@@ -24,7 +24,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/connect": "^0.0.4",
+    "@farcaster/connect": "^0.0.5",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/connect
 
+## 0.0.5
+
+### Patch Changes
+
+- 6e70ebc: Remove @farcaster/core dependency
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Change Summary

Publish new packages, removing `@farcaster/core` dependency.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed

