### PR TITLE
chore: publish connect@0.0.6 and connect-kit@0.0.8

### DIFF
--- a/.changeset/great-jars-hammer.md
+++ b/.changeset/great-jars-hammer.md
@@ -1,6 +1,0 @@
----
-"@farcaster/connect-kit": patch
-"@farcaster/connect": patch
----
-
-Chore: prune bundles

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # connect-kit
 
+## 0.0.8
+
+### Patch Changes
+
+- d906f3c: Chore: prune bundles
+- Updated dependencies [d906f3c]
+  - @farcaster/connect@0.0.6
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect-kit",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "./dist/connect-kit.umd.cjs",
   "module": "./dist/connect-kit.js",
@@ -24,7 +24,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/connect": "^0.0.5",
+    "@farcaster/connect": "^0.0.6",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/connect
 
+## 0.0.6
+
+### Patch Changes
+
+- d906f3c: Chore: prune bundles
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Change Summary

Release `connect@0.0.6` and `connect-kit@0.08`, with smaller bundle sizes.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed