### PR TITLE
fix: pass authKey in client

### DIFF
--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # connect-kit
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @farcaster/connect@0.0.8
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect-kit",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "./dist/connect-kit.umd.cjs",
   "module": "./dist/connect-kit.js",
@@ -24,7 +24,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/connect": "^0.0.7",
+    "@farcaster/connect": "^0.0.8",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/connect
 
+## 0.0.8
+
+### Patch Changes
+
+- Add authKey arg to authClient.authenticate
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/connect/src/actions/auth/authenticate.test.ts
+++ b/packages/connect/src/actions/auth/authenticate.test.ts
@@ -38,6 +38,7 @@ describe("authenticate", () => {
     const spy = jest.spyOn(global, "fetch").mockResolvedValue(response);
 
     const res = await client.authenticate({
+      authKey: "some-auth-key",
       channelToken: "some-channel-token",
       message,
       signature,
@@ -64,6 +65,7 @@ describe("authenticate", () => {
       headers: {
         "Content-Type": "application/json",
         Authorization: "Bearer some-channel-token",
+        "X-Farcaster-Connect-Auth-Key": "some-auth-key",
       },
     });
   });

--- a/packages/connect/src/actions/auth/authenticate.ts
+++ b/packages/connect/src/actions/auth/authenticate.ts
@@ -4,6 +4,7 @@ import { Client } from "../../clients/createClient";
 import { AsyncUnwrapped, unwrap } from "../../errors";
 
 export interface AuthenticateArgs extends AuthenticateRequest {
+  authKey: string;
   channelToken: string;
 }
 
@@ -25,10 +26,13 @@ const path = "connect/authenticate";
 
 export const authenticate = async (
   client: Client,
-  { channelToken, ...request }: AuthenticateArgs,
+  { channelToken, authKey, ...request }: AuthenticateArgs,
 ): AuthenticateResponse => {
   const result = await post<AuthenticateRequest, AuthenticateAPIResponse>(client, path, request, {
     authToken: channelToken,
+    headers: {
+      "X-Farcaster-Connect-Auth-Key": authKey,
+    },
   });
   return unwrap(result);
 };

--- a/test/client/.env.test
+++ b/test/client/.env.test
@@ -1,0 +1,1 @@
+AUTH_KEY=farcaster-connect-auth-key

--- a/test/client/CHANGELOG.md
+++ b/test/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # client-test
 
+## 0.0.3
+
+### Patch Changes
+
+- Add authKey arg to authClient.authenticate
+
 ## 0.0.2
 
 ### Patch Changes

--- a/test/client/package.json
+++ b/test/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-test",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "test": " DOTENV_CONFIG_PATH=.env.test jest",

--- a/test/client/package.json
+++ b/test/client/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "test": "jest",
-    "test:ci": "ENVIRONMENT=test jest --ci --forceExit --coverage",
+    "test": " DOTENV_CONFIG_PATH=.env.test jest",
+    "test:ci": "ENVIRONMENT=test DOTENV_CONFIG_PATH=.env.test jest --ci --forceExit --coverage",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/"
   },

--- a/test/client/src/e2e.test.ts
+++ b/test/client/src/e2e.test.ts
@@ -95,6 +95,7 @@ describe("clients", () => {
       // 3e. Send back signed message
       const { response: authResponse } = await authClient.authenticate({
         channelToken,
+        authKey: "farcaster-connect-auth-key",
         message: messageString,
         signature: sig,
         ...userData,


### PR DESCRIPTION
## Change Summary

v1 requests to `/authenticate` are restricted to Warpcast using an auth key header. Add an `authKey` arg to the `authenticate` actoin.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
