### PR TITLE
feat: pass nonce and domain to verify

### DIFF
--- a/packages/connect-kit/src/hooks/useSignIn.ts
+++ b/packages/connect-kit/src/hooks/useSignIn.ts
@@ -24,7 +24,10 @@ const defaults = {
 
 export function useSignIn(args: UseSignInArgs) {
   const appClient = useAppClient();
-  const { onSignIn } = useConnectContext();
+  const {
+    onSignIn,
+    config: { domain },
+  } = useConnectContext();
   const { timeout, interval, onSuccess, onStatusResponse, onError, ...connectArgs } = {
     ...defaults,
     ...args,
@@ -33,7 +36,7 @@ export function useSignIn(args: UseSignInArgs) {
   const {
     connect,
     reconnect,
-    data: { channelToken, connectUri, qrCodeUri },
+    data: { channelToken, connectUri, qrCodeUri, nonce },
     isError: isConnectError,
     error: connectError,
   } = useConnect({ ...connectArgs, onError });
@@ -57,6 +60,8 @@ export function useSignIn(args: UseSignInArgs) {
     isError: isVerifyError,
     error: verifyError,
   } = useVerifySignInMessage({
+    nonce,
+    domain,
     message: statusData?.message,
     signature: statusData?.signature,
     onError,

--- a/packages/connect-kit/src/hooks/useVerifySignInMessage.ts
+++ b/packages/connect-kit/src/hooks/useVerifySignInMessage.ts
@@ -3,17 +3,28 @@ import { ConnectError } from "@farcaster/connect";
 import useAppClient from "./useAppClient";
 
 export interface UseVerifySignInMessageArgs {
+  nonce?: string;
+  domain?: string;
   message?: string;
   signature?: `0x${string}`;
   onSuccess?: (statusData: UseVerifySignInMessageData) => void;
   onError?: (error?: ConnectError) => void;
 }
 
-export type UseVerifySignInMessageData = UseVerifySignInMessageArgs & {
+export interface UseVerifySignInMessageData {
+  message?: string;
+  signature?: `0x${string}`;
   validSignature: boolean;
-};
+}
 
-export function useVerifySignInMessage({ message, signature, onSuccess, onError }: UseVerifySignInMessageArgs) {
+export function useVerifySignInMessage({
+  nonce,
+  domain,
+  message,
+  signature,
+  onSuccess,
+  onError,
+}: UseVerifySignInMessageArgs) {
   const appClient = useAppClient();
 
   const [validSignature, setValidSignature] = useState<boolean>(false);
@@ -28,12 +39,14 @@ export function useVerifySignInMessage({ message, signature, onSuccess, onError 
   };
 
   const verifySignInMessage = useCallback(async () => {
-    if (appClient && message && signature) {
+    if (appClient && nonce && domain && message && signature) {
       const {
         success,
         isError: isVerifyError,
         error: verifyError,
       } = await appClient.verifySignInMessage({
+        nonce,
+        domain,
         message,
         signature,
       });
@@ -47,14 +60,14 @@ export function useVerifySignInMessage({ message, signature, onSuccess, onError 
         onSuccess?.({ message, signature, validSignature: success });
       }
     }
-  }, [appClient, message, signature, onSuccess, onError]);
+  }, [appClient, nonce, domain, message, signature, onSuccess, onError]);
 
   useEffect(() => {
     resetState();
-    if (message && signature) {
+    if (nonce && domain && message && signature) {
       verifySignInMessage();
     }
-  }, [message, signature, verifySignInMessage]);
+  }, [nonce, domain, message, signature, verifySignInMessage]);
 
   return {
     isSuccess,

--- a/packages/connect/src/actions/app/connect.ts
+++ b/packages/connect/src/actions/app/connect.ts
@@ -17,6 +17,7 @@ interface ConnectRequest {
 interface ConnectAPIResponse {
   channelToken: string;
   connectUri: string;
+  nonce: string;
 }
 
 const path = "connect";

--- a/packages/connect/src/actions/app/verifySignInMessage.test.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.test.ts
@@ -20,7 +20,9 @@ describe("verifySignInMessage", () => {
     uri: "https://example.com/login",
     version: "1",
     issuedAt: "2023-10-01T00:00:00.000Z",
+    nonce: "abcd1234",
   };
+  const { nonce, domain } = siweParams;
 
   test("verifies sign in message", async () => {
     const { message } = authClient.buildSignInMessage({
@@ -36,6 +38,8 @@ describe("verifySignInMessage", () => {
     const errMsg = `Invalid resource: signer ${account.address} does not own fid 1234.`;
     const err = new ConnectError("unauthorized", errMsg);
     const { isError, error } = await client.verifySignInMessage({
+      nonce,
+      domain,
       message,
       signature,
     });
@@ -58,6 +62,8 @@ describe("verifySignInMessage", () => {
     const errMsg = `Invalid resource: signer ${LGTM} does not own fid 1234.`;
     const err = new ConnectError("unauthorized", errMsg);
     const { isError, error } = await client.verifySignInMessage({
+      nonce,
+      domain,
       message,
       signature,
     });

--- a/packages/connect/src/actions/app/verifySignInMessage.ts
+++ b/packages/connect/src/actions/app/verifySignInMessage.ts
@@ -4,6 +4,8 @@ import { VerifyResponse, verify } from "../../messages/verify";
 import { Unwrapped, unwrap } from "../../errors";
 
 export interface VerifySignInMessageArgs {
+  nonce: string;
+  domain: string;
   message: string | Partial<SiweMessage>;
   signature: `0x${string}`;
 }
@@ -12,9 +14,9 @@ export type VerifySignInMessageResponse = Promise<Unwrapped<VerifyResponse>>;
 
 export const verifySignInMessage = async (
   client: Client,
-  { message, signature }: VerifySignInMessageArgs,
+  { nonce, domain, message, signature }: VerifySignInMessageArgs,
 ): VerifySignInMessageResponse => {
-  const result = await verify(message, signature, {
+  const result = await verify(nonce, domain, message, signature, {
     getFid: client.ethereum.getFid,
     provider: client.ethereum.provider,
   });


### PR DESCRIPTION
## Change Summary

Require an explicit `nonce` and `domain` in calls to `verifySignInMessage` and hooks.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed