### PR TITLE
fix: return nonce from connect

### DIFF
--- a/.changeset/dull-rocks-clean.md
+++ b/.changeset/dull-rocks-clean.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/connect-relay": patch
+---
+
+fix: return nonce from /v1/connect

--- a/apps/relay/src/handlers.ts
+++ b/apps/relay/src/handlers.ts
@@ -54,7 +54,7 @@ export async function connect(request: FastifyRequest<{ Body: ConnectRequest }>,
       connectUri,
     });
     if (update.isOk()) {
-      reply.code(201).send({ channelToken, connectUri });
+      reply.code(201).send({ channelToken, connectUri, nonce });
     } else {
       reply.code(500).send({ error: update.error.message });
     }

--- a/apps/relay/src/server.test.ts
+++ b/apps/relay/src/server.test.ts
@@ -73,35 +73,36 @@ describe("relay server", () => {
       const response = await http.post(getFullUrl("/v1/connect"), connectParams);
 
       expect(response.status).toBe(201);
-      const { channelToken, connectUri, ...rest } = response.data;
+      const { channelToken, connectUri, nonce, ...rest } = response.data;
       expect(channelToken).toMatch(/[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}/);
       expect(rest).toStrictEqual({});
     });
 
     test("creates a channel with extra SIWE parameters", async () => {
-      const nonce = "some-custom-nonce";
+      const customNonce = "some-custom-nonce";
       const notBefore = "2023-01-01T00:00:00Z";
       const expirationTime = "2023-12-31T00:00:00Z";
       const requestId = "some-request-id";
       const response = await http.post(getFullUrl("/v1/connect"), {
         ...connectParams,
-        nonce,
+        nonce: customNonce,
         notBefore,
         expirationTime,
         requestId,
       });
 
       expect(response.status).toBe(201);
-      const { channelToken, connectUri, ...rest } = response.data;
+      const { channelToken, connectUri, nonce, ...rest } = response.data;
       // parse query params from URI
       const params = new URLSearchParams(connectUri.split("?")[1]);
       expect(params.get("siweUri")).toBe(connectParams.siweUri);
       expect(params.get("domain")).toBe(connectParams.domain);
-      expect(params.get("nonce")).toBe(nonce);
+      expect(params.get("nonce")).toBe(customNonce);
       expect(params.get("notBefore")).toBe(notBefore);
       expect(params.get("expirationTime")).toBe(expirationTime);
       expect(params.get("requestId")).toBe(requestId);
       expect(channelToken).toMatch(/[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}/);
+      expect(nonce).toBe(customNonce);
       expect(rest).toStrictEqual({});
     });
 


### PR DESCRIPTION
## Change Summary

The relay server should return `nonce` from `/connect`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
