### PR TITLE
fix: Log in to Docker Hub to avoid rate limit errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Run build
         run: yarn build
 
+      - name: Log in to Docker Hub to avoid rate limiting
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_USER }}
+          password: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_TOKEN }}
+
       - name: Start background services
         shell: bash
         run: docker compose -f ./apps/relay/docker-compose.yml up --build --detach redis


### PR DESCRIPTION
## Motivation

We need to log in to Docker Hub in order to avoid being rate limited.

## Change Summary

Use our standard read-only credentials.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes documentation if necessary
- [x] All commits have been signed

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
