### PR TITLE
fix: add changeset for peer dependency change

### DIFF
--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # connect-kit
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies [23c673f]
+  - @farcaster/connect@0.0.15
+
 ## 0.0.27
 
 ### Patch Changes

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect-kit",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "main": "./dist/connect-kit.js",
   "types": "./dist/connect-kit.d.ts",
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/connect": "^0.0.14",
+    "@farcaster/connect": "^0.0.15",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/connect
 
+## 0.0.15
+
+### Patch Changes
+
+- 23c673f: update Viem peer dependency
+
 ## 0.0.14
 
 ### Patch Changes

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/connect",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Change Summary

Missed a changeset for the updated peer dependency in `connect`, use this one to force a version bump.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
