### PR TITLE
fix: ethers v5/v6 compatibility

### DIFF
--- a/packages/auth-client/CHANGELOG.md
+++ b/packages/auth-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/auth-client
 
+## 0.0.20
+
+### Patch Changes
+
+- Fix: Ethers v5/v6 compatibility
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-client",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/auth-client/src/clients/ethereum/connector.ts
+++ b/packages/auth-client/src/clients/ethereum/connector.ts
@@ -1,7 +1,7 @@
 import { Hex } from "viem";
-import type { providers } from "ethers";
+import type { Provider } from "./ethers";
 
 export interface EthereumConnector {
   getFid: (custody: Hex) => Promise<BigInt>;
-  provider: providers.JsonRpcProvider;
+  provider: Provider;
 }

--- a/packages/auth-client/src/clients/ethereum/ethers.ts
+++ b/packages/auth-client/src/clients/ethereum/ethers.ts
@@ -1,0 +1,11 @@
+import * as ethers from "ethers";
+
+export const JsonRpcProvider =
+  // @ts-expect-error -- ethers v6 compatibility hack
+  ethers.providers ? ethers.providers.JsonRpcProvider : ethers.JsonRpcProvider;
+
+export const Provider =
+  // @ts-expect-error -- ethers v6 compatibility hack
+  ethers.providers ? ethers.providers.Provider : ethers.Provider;
+
+export type Provider = typeof Provider;

--- a/packages/auth-client/src/clients/ethereum/viemConnector.ts
+++ b/packages/auth-client/src/clients/ethereum/viemConnector.ts
@@ -1,8 +1,8 @@
 import { Hex, createPublicClient, http } from "viem";
 import { optimism } from "viem/chains";
-import * as ethers from "ethers";
 import { ID_REGISTRY_ADDRESS, idRegistryABI } from "../../contracts/idRegistry";
 import { EthereumConnector } from "./connector";
+import { JsonRpcProvider } from "./ethers";
 
 interface ViemConfigArgs {
   rpcUrl?: string;
@@ -30,13 +30,7 @@ export const viemConnector = (args?: ViemConfigArgs): EthereumConnector => {
       name: chain.name,
     };
     const rpc = transport.url ?? chain.rpcUrls.default.http[0];
-
-    return new (
-      ethers.providers
-        ? ethers.providers.JsonRpcProvider
-        : // @ts-expect-error -- ethers v6 compatibility hack
-          ethers.JsonRpcProvider
-    )(rpc, network);
+    return new JsonRpcProvider(rpc, network);
   };
 
   return {

--- a/packages/auth-client/src/messages/verify.ts
+++ b/packages/auth-client/src/messages/verify.ts
@@ -1,15 +1,15 @@
 import { SiweMessage, SiweResponse, SiweError } from "siwe";
 import { ResultAsync, err, ok } from "neverthrow";
-import type { providers } from "ethers";
 import { AuthClientAsyncResult, AuthClientResult, AuthClientError } from "../errors";
 
 import { validate, parseResources } from "./validate";
 import { FarcasterResourceParams } from "./build";
+import type { Provider } from "../clients/ethereum/ethers";
 
 type Hex = `0x${string}`;
 type SignInOpts = {
   getFid: (custody: Hex) => Promise<BigInt>;
-  provider?: providers.Provider;
+  provider?: Provider;
 };
 export type VerifyResponse = Omit<SiweResponse, "error"> & FarcasterResourceParams;
 
@@ -70,7 +70,7 @@ const validateDomain = (message: SiweMessage, domain: string): AuthClientResult<
 const verifySiweMessage = async (
   message: SiweMessage,
   signature: string,
-  provider?: providers.Provider,
+  provider?: Provider,
 ): AuthClientAsyncResult<SiweResponse> => {
   return ResultAsync.fromPromise(message.verify({ signature }, { provider, suppressExceptions: true }), (e) => {
     return new AuthClientError("unauthorized", e as Error);

--- a/packages/auth-kit/CHANGELOG.md
+++ b/packages/auth-kit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/auth-kit
 
+## 0.0.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @farcaster/auth-client@0.0.20
+
 ## 0.0.33
 
 ### Patch Changes

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-kit",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "type": "module",
   "main": "./dist/auth-kit.js",
   "types": "./dist/auth-kit.d.ts",
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/auth-client": "^0.0.19",
+    "@farcaster/auth-client": "^0.0.20",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"


### PR DESCRIPTION
## Change Summary

Add `ethers.ts` module to handle Ethers v5/v6 compatibility.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed