### PR TITLE
fix: ethers compatibility

### DIFF
--- a/packages/auth-client/CHANGELOG.md
+++ b/packages/auth-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/auth-client
 
+## 0.0.21
+
+### Patch Changes
+
+- Fix: Ethers v5/v6 compatibility hack
+
 ## 0.0.20
 
 ### Patch Changes

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-client",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/auth-client/src/clients/ethereum/ethers.ts
+++ b/packages/auth-client/src/clients/ethereum/ethers.ts
@@ -1,11 +1,13 @@
 import * as ethers from "ethers";
 
+const { providers } = ethers;
+
 export const JsonRpcProvider =
   // @ts-expect-error -- ethers v6 compatibility hack
-  ethers.providers ? ethers.providers.JsonRpcProvider : ethers.JsonRpcProvider;
+  providers ? providers.JsonRpcProvider : ethers.JsonRpcProvider;
 
 export const Provider =
   // @ts-expect-error -- ethers v6 compatibility hack
-  ethers.providers ? ethers.providers.Provider : ethers.Provider;
+  providers ? providers.Provider : ethers.Provider;
 
 export type Provider = typeof Provider;

--- a/packages/auth-kit/CHANGELOG.md
+++ b/packages/auth-kit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/auth-kit
 
+## 0.0.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @farcaster/auth-client@0.0.21
+
 ## 0.0.34
 
 ### Patch Changes

--- a/packages/auth-kit/package.json
+++ b/packages/auth-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/auth-kit",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "type": "module",
   "main": "./dist/auth-kit.js",
   "types": "./dist/auth-kit.d.ts",
@@ -18,7 +18,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@farcaster/auth-client": "^0.0.20",
+    "@farcaster/auth-client": "^0.0.21",
     "@vanilla-extract/css": "^1.14.0",
     "qrcode": "^1.5.3",
     "react-remove-scroll": "^2.5.7"


### PR DESCRIPTION
## Change Summary

We also need to destructure `ethers` here to avoid an import error.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a changeset
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes documentation if necessary
- [x] All commits have been signed
