### PR TITLE
Typo fix Update CHANGELOG.md

### DIFF
--- a/packages/auth-kit/CHANGELOG.md
+++ b/packages/auth-kit/CHANGELOG.md
@@ -196,7 +196,7 @@
 
 ### Patch Changes
 
-- 1c02300: relax react-dom and viem peerDependency verion ranges
+- 1c02300: relax react-dom and viem peerDependency version ranges
 - 55d37f4: esm only build
 
 ## 0.0.25


### PR DESCRIPTION
# Fix Typo in CHANGELOG.md

This pull request fixes a minor typo in the `CHANGELOG.md` file. Specifically:
- Corrected `verion` to `version`.

No functional changes were made, ensuring the documentation is more precise and professional.

---

### Changes:
```diff
- relax react-dom and viem peerDependency verion ranges
+ relax react-dom and viem peerDependency version ranges
