### PR TITLE
fix: pre-download node-gyp headers to avoid install race condition

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -64,7 +64,7 @@ COPY --chown=node:node --from=prune /home/node/app/apps/relay/package.json ./app
 COPY --chown=node:node --from=prune /home/node/app/packages/ ./packages/
 
 # Pre-download node-gyp headers to avoid parallel download race conditions
-RUN npx node-gyp install
+RUN pnpm dlx node-gyp@12.2.0 install
 
 # Install dependencies for relay and its dependencies
 RUN pnpm install --frozen-lockfile --filter=@farcaster/auth-relay...

--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -63,6 +63,9 @@ COPY --chown=node:node --from=prune /home/node/app/turbo.json ./turbo.json
 COPY --chown=node:node --from=prune /home/node/app/apps/relay/package.json ./apps/relay/package.json
 COPY --chown=node:node --from=prune /home/node/app/packages/ ./packages/
 
+# Pre-download node-gyp headers to avoid parallel download race conditions
+RUN npx node-gyp install
+
 # Install dependencies for relay and its dependencies
 RUN pnpm install --frozen-lockfile --filter=@farcaster/auth-relay...
 


### PR DESCRIPTION
## Summary
- Adds `RUN npx node-gyp install` before `pnpm install` in Dockerfile.relay
- This pre-downloads Node.js headers so that multiple native addon compilations during `pnpm install` don't race to download the same headers simultaneously

## Files changed
- `Dockerfile.relay` - added `RUN npx node-gyp install` before the first `pnpm install --frozen-lockfile`