### PR TITLE
fix: add exports map to @farcaster/jfs for correct ESM resolution

### DIFF
--- a/.changeset/gold-baboons-attend.md
+++ b/.changeset/gold-baboons-attend.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/jfs": minor
+---
+
+make ESM imports work correctly on Vercel

--- a/packages/jfs/package.json
+++ b/packages/jfs/package.json
@@ -9,6 +9,12 @@
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "build": "pnpm build:cjs && pnpm build:esm",


### PR DESCRIPTION
## Summary

- Adds an `"exports"` field to `@farcaster/jfs` `package.json` so Node.js ESM consumers resolve to `dist/esm/index.js` instead of falling back to `"main"` (CJS)
- Fixes `ERR_REQUIRE_ESM` when `@farcaster/jfs` is imported from ESM packages on Node.js (e.g. Vercel serverless functions), caused by the CJS build doing `require("@noble/curves/ed25519.js")` against ESM-only `@noble/curves` v2

## Test plan

- [x] `pnpm build` succeeds (both CJS and ESM outputs)
- [x] `pnpm test` passes (54/54 tests)
- [x] Verified Node ESM `import` resolves to `dist/esm/index.js`
- [ ] After publish, verify `@farcaster/snap` deploys to Vercel without `ERR_REQUIRE_ESM`

Made with [Cursor](https://cursor.com)