### PR TITLE
feat: ship dual-format @farcaster/jfs builds

### DIFF
--- a/.changeset/tough-mugs-visit.md
+++ b/.changeset/tough-mugs-visit.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/jfs": minor
+---
+
+Build `@farcaster/jfs` with `tsup` and publish proper ESM/CJS entrypoints.
+
+The package now exposes real dual-format exports with working `import` and `require` entrypoints.

--- a/.changeset/tough-mugs-visit.md
+++ b/.changeset/tough-mugs-visit.md
@@ -5,3 +5,5 @@
 Build `@farcaster/jfs` with `tsup` and publish proper ESM/CJS entrypoints.
 
 The package now exposes real dual-format exports with working `import` and `require` entrypoints.
+
+Deep imports such as `@farcaster/jfs/dist/*` are no longer supported now that the package uses an `exports` map.

--- a/packages/jfs/package.json
+++ b/packages/jfs/package.json
@@ -27,12 +27,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@noble/curves": "2.x",
     "typescript": ">= 5.8.3",
     "viem": "2.x"
   },
+  "dependencies": {
+    "@noble/curves": "2.x"
+  },
   "devDependencies": {
-    "@noble/curves": "2.x",
     "viem": "^2.37.13",
     "vitest": "^3.2.4"
   },

--- a/packages/jfs/package.json
+++ b/packages/jfs/package.json
@@ -7,13 +7,19 @@
     "url": "https://github.com/farcasterxyz/auth-monorepo.git",
     "directory": "packages/jfs"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "pnpm build:cjs && pnpm build:esm",
-    "build:cjs": "tsc --module commonjs --moduleResolution node --outDir dist/cjs",
-    "build:esm": "tsc --outDir dist/esm",
+    "build": "tsup --config tsup.config.ts",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/jfs/src/index.ts
+++ b/packages/jfs/src/index.ts
@@ -1,6 +1,6 @@
 import { type Hex, isAddress, verifyMessage, isHex, hexToBytes } from "viem";
 import { ed25519 } from "@noble/curves/ed25519.js";
-import { toBase64Url, fromBase64Url } from "./utils";
+import { toBase64Url, fromBase64Url } from "./utils.js";
 
 export interface VerifyMessageClient {
   verifyMessage(args: { address: Hex; message: string; signature: Hex | Uint8Array }): Promise<boolean>;

--- a/packages/jfs/tsconfig.json
+++ b/packages/jfs/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "moduleResolution": "nodenext",
-    "module": "nodenext",
-    "target": "ES2021",
+    "moduleResolution": "bundler",
+    "module": "ES2022",
+    "target": "ES2022",
     "esModuleInterop": true,
     "strict": true,
     "declaration": true,

--- a/packages/jfs/tsup.config.ts
+++ b/packages/jfs/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  target: ["es2021"],
+  target: ["es2022"],
   entryPoints: ["src/index.ts"],
   format: ["esm", "cjs"],
   noExternal: ["@noble/curves"],

--- a/packages/jfs/tsup.config.ts
+++ b/packages/jfs/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  target: ["es2021"],
+  entryPoints: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  noExternal: ["@noble/curves"],
+  dts: true,
+  clean: true,
+  shims: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,13 +295,13 @@ importers:
 
   packages/jfs:
     dependencies:
+      '@noble/curves':
+        specifier: 2.x
+        version: 2.0.1
       typescript:
         specifier: '>= 5.8.3'
         version: 5.8.3
     devDependencies:
-      '@noble/curves':
-        specifier: 2.x
-        version: 2.0.1
       viem:
         specifier: ^2.37.13
         version: 2.37.13(typescript@5.8.3)


### PR DESCRIPTION
## Summary
- build `@farcaster/jfs` with `tsup` instead of the previous hand-rolled dual `tsc` pipeline
- publish real dual-format package entrypoints via `./dist/index.js` and `./dist/index.mjs`, with an exports map and ESM-safe source imports
- add a Changesets minor release entry for `@farcaster/jfs` so the repo can generate the versioning PR on `main`

## Test plan
- [x] `pnpm changeset status`
- [x] `pnpm --filter @farcaster/jfs build`
- [x] `node --input-type=module -e "import('./packages/jfs/dist/index.mjs').then((mod) => { console.log(typeof mod.verify, typeof mod.compact); })"`
- [x] `node -e "const mod = require('./packages/jfs/dist/index.js'); console.log(typeof mod.verify, typeof mod.compact);"`
- [x] `pnpm --filter @farcaster/jfs typecheck`
- [x] `pnpm --filter @farcaster/jfs test`


Made with [Cursor](https://cursor.com)