### PR TITLE
docs: `viemConnector` examples pass a bare string and silently use the public RPC

### DIFF
--- a/packages/auth-client/README.md
+++ b/packages/auth-client/README.md
@@ -41,7 +41,7 @@ To use a custom RPC, pass an RPC URL to the viem connector.
 
 Type: `Ethereum`
 
-Example: `viemConnector("http://mainnet.optimism.io")`
+Example: `viemConnector({ rpcUrl: "http://mainnet.optimism.io" })`
 
 ##### relay (optional)
 
@@ -353,7 +353,7 @@ To use a custom RPC, pass an RPC URl to the viem connector.
 
 Type: `Ethereum`
 
-Example: `viem("http://mainnet.optimism.io")`
+Example: `viemConnector({ rpcUrl: "http://mainnet.optimism.io" })`
 
 ##### relay (optional)
 


### PR DESCRIPTION
## Problem

`packages/auth-client/README.md` documents the connector twice, and both examples are wrong.

**Line 44** — `Example: viemConnector("http://mainnet.optimism.io")`

The signature is an options object (`src/clients/ethereum/viemConnector.ts:12`):

```ts
interface ViemConfigArgs {
  rpcUrl?: string | undefined;
  rpcUrls?: string[] | undefined;
}
export const viemConnector = (args?: ViemConfigArgs): EthereumConnector => {
```

A bare string is not an error at runtime — it lands in `args`, `args?.rpcUrl` is `undefined`, and the connector takes the fallback branch:

```ts
if (!args?.rpcUrl) {
  console.warn("No `rpcUrl` provided to Viem connector, using public endpoint. Do not use this in production");
}
```

So a developer who follows the documented example to point at their own node ships the public endpoint instead, with only a console warning between them and the very thing the warning says not to do in production.

**Line 356** — `Example: viem("http://mainnet.optimism.io")`

Wrong on both counts: there is no `viem` export (`src/clients/ethereum/index.ts` re-exports `viemConnector`), and the argument is a bare string again. This one would not even compile.

## Fix

Both examples become:

```
viemConnector({ rpcUrl: "http://mainnet.optimism.io" })
```

Two lines, README only.